### PR TITLE
ci: add golangci-lint to GitHub Actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: latest
+        version: v2.12.2
         only-new-issues: true
 
     - name: Run Fuzz Checks (Sanity)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,10 @@ jobs:
     - name: Verify Dependencies
       run: go mod verify
 
-    - name: Static Analysis (Vet)
-      run: go vet ./...
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        only-new-issues: true
 
     - name: Run Fuzz Checks (Sanity)
       run: go test -fuzz=FuzzScanner -fuzztime=15s ./pkg/scanner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
+        version: latest
         only-new-issues: true
 
     - name: Run Fuzz Checks (Sanity)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       run: go mod verify
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
         version: v2.12.2
         only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,13 +3,12 @@ version: '2'
 run:
   go: '1.24'
 
-formatters:
+linters:
   enable:
     - gofmt
-linters:
-  default: standard
-  exclusions:
-    rules:
-      - path: '(.+)_test\.go'
-        linters:
-          - errcheck
+
+issues:
+  exclude-rules:
+    - path: '.*_test\.go'
+      linters:
+        - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+version: '2'
+
+formatters:
+  enable:
+    - gofmt
+linters:
+  default: standard
+  exclusions:
+    rules:
+      - path: '(.+)_test\.go'
+        linters:
+          - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,8 @@
 version: '2'
 
+run:
+  go: '1.24'
+
 formatters:
   enable:
     - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,12 @@
-run:
-  go: '1.24'
+version: '2'
 
-linters:
+formatters:
   enable:
     - gofmt
-
-issues:
-  exclude-rules:
-    - path: '.*_test\.go'
-      linters:
-        - errcheck
+linters:
+  default: standard
+  exclusions:
+    rules:
+      - path: '(.+)_test\.go'
+        linters:
+          - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 run:
   go: '1.24'
 

--- a/cmd/cleaner/main.go
+++ b/cmd/cleaner/main.go
@@ -79,7 +79,9 @@ func main() {
 
 		go func() {
 			<-sigChan
-			t.Stop()
+			if err := t.Stop(); err != nil {
+				log.Printf("Failed to stop tail: %v", err)
+			}
 		}()
 
 		for line := range t.Lines {

--- a/cmd/cleaner/main.go
+++ b/cmd/cleaner/main.go
@@ -25,7 +25,7 @@ func main() {
 		if port == "" {
 			port = "9090"
 		}
-		
+
 		// Wire metrics callback
 		scanner.RedactionCallback = metrics.IncrementRedaction
 
@@ -40,7 +40,7 @@ func main() {
 
 	failPolicy := os.Getenv("PII_FAIL_POLICY")
 	if failPolicy == "" {
-		failPolicy = "open" // Start with fail-open by default 
+		failPolicy = "open" // Start with fail-open by default
 	}
 
 	var watchFile string
@@ -132,7 +132,7 @@ func processLine(text string, metricsEnabled bool, failPolicy string) {
 				if failPolicy == "closed" {
 					fmt.Println("[PII_SHIELD_DROP: FATAL_ERROR]")
 				} else {
-					// Fail-Open: keep the flow alive 
+					// Fail-Open: keep the flow alive
 					fmt.Println(text)
 				}
 			}

--- a/pkg/scanner/adaptive.go
+++ b/pkg/scanner/adaptive.go
@@ -65,7 +65,8 @@ func (bs *BaselineStats) GetThreshold() (float64, bool) {
 	// Calculate stddev
 	variance := 0.0
 	for _, v := range bs.samples {
-		variance += math.Pow(v-mean, 2)
+		diff := v - mean
+		variance += diff * diff
 	}
 	stddev := math.Sqrt(variance / float64(len(bs.samples)))
 

--- a/pkg/scanner/adaptive_test.go
+++ b/pkg/scanner/adaptive_test.go
@@ -62,11 +62,10 @@ func TestBaselineStats_HardReset(t *testing.T) {
 	if stats.ready != false {
 		t.Error("Expected ready to be false after hard reset")
 	}
-	
+
 	// 4. Verify it can start over perfectly
 	stats.Update(1.0)
 	if len(stats.samples) != 1 {
 		t.Errorf("Expected 1 sample after starting over, got %d", len(stats.samples))
 	}
 }
-

--- a/pkg/scanner/config_coverage_test.go
+++ b/pkg/scanner/config_coverage_test.go
@@ -55,7 +55,7 @@ func TestLoadConfigEdgeCases(t *testing.T) {
 	if !reflect.DeepEqual(cfg.SensitiveKeys, expectedKeys) {
 		t.Errorf("expected sensitive keys %v, got: %v", expectedKeys, cfg.SensitiveKeys)
 	}
-	
+
 	// Ensure UpdateConfig functions well
 	UpdateConfig(cfg)
 }

--- a/pkg/scanner/falsepos_test.go
+++ b/pkg/scanner/falsepos_test.go
@@ -66,13 +66,13 @@ func TestFalsePositives(t *testing.T) {
 		// Just a 16-digit random number that happens to pass Luhn (we need a valid Luhn for this test)
 		luhnValid := "4556737586899855"
 		input := fmt.Sprintf("TraceId=%s", luhnValid)
-		
+
 		output := ScanAndRedact(input)
 		// It should NOT redact because no CC context and threshold is high
 		if output != input {
 			t.Errorf("Expected plain traceId pass-through for Luhn FP, got %s", output)
 		}
-		
+
 		// But WITH context it should redact
 		inputWithCtx := fmt.Sprintf("visa card %s provided", luhnValid)
 		outputCtx := ScanAndRedact(inputWithCtx)

--- a/pkg/scanner/fuzz_regression_test.go
+++ b/pkg/scanner/fuzz_regression_test.go
@@ -9,9 +9,9 @@ func TestReproFuzzFailure(t *testing.T) {
 	// Input: "\"\\\x80"
 	// quote, backslash, invalid byte (0x80)
 	input := "\"\\\x80"
-	
+
 	output := ScanAndRedact(input)
-	
+
 	if !utf8.ValidString(output) {
 		t.Errorf("Scanner produced invalid UTF-8 for input %q. Output byte len: %d", input, len(output))
 	}

--- a/pkg/scanner/performance_test.go
+++ b/pkg/scanner/performance_test.go
@@ -102,7 +102,7 @@ func BenchmarkBlacklist_Regex(b *testing.B) {
 	pattern := `(?i)(custom_secret|super_confidential)`
 	re := regexp.MustCompile(pattern)
 	sensitiveRegex = re // Direct assignment for test
-	
+
 	// A key NOT in static list, but matches regex
 	key := "custom_secret"
 

--- a/pkg/scanner/regex_redaction_test.go
+++ b/pkg/scanner/regex_redaction_test.go
@@ -21,9 +21,9 @@ func TestScanner_CustomRegexRedaction(t *testing.T) {
 		expectedOutput string
 	}{
 		{
-			name:           "Account Redaction (Named)",
-			regexConfig:    `[{"pattern": "^ACCT-[0-9]{10}$", "name": "Account"}]`,
-			input:          "User ID: ACCT-1234567890",
+			name:        "Account Redaction (Named)",
+			regexConfig: `[{"pattern": "^ACCT-[0-9]{10}$", "name": "Account"}]`,
+			input:       "User ID: ACCT-1234567890",
 			// Expect: [HIDDEN:Account:HexHash]
 			expectedOutput: `User ID: \[HIDDEN:Account:[a-f0-9]{6}\]`,
 		},
@@ -34,9 +34,9 @@ func TestScanner_CustomRegexRedaction(t *testing.T) {
 			expectedOutput: `License: \[HIDDEN:TX:[a-f0-9]{6}\]`,
 		},
 		{
-			name:           "Account Redaction (Unnamed)",
-			regexConfig:    `[{"pattern": "^ACCT-[0-9]{10}$", "name": ""}]`,
-			input:          "Transaction: ACCT-1234567890",
+			name:        "Account Redaction (Unnamed)",
+			regexConfig: `[{"pattern": "^ACCT-[0-9]{10}$", "name": ""}]`,
+			input:       "Transaction: ACCT-1234567890",
 			// Expect: [HIDDEN:HexHash] (Wait, redactWithHMAC adds extra colon if name empty? Let's check logic)
 			// Logic: if name != "" { append :name }; append :hash
 			// So if name is empty: [HIDDEN:hash]
@@ -70,7 +70,7 @@ func TestScanner_CustomRegexRedaction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tConfig := originalConfig // Copy defaults
+			tConfig := originalConfig                   // Copy defaults
 			tConfig.CustomRegexes = []CustomRegexRule{} // Reset
 
 			if tt.regexConfig != "" {
@@ -90,12 +90,12 @@ func TestScanner_CustomRegexRedaction(t *testing.T) {
 			currentConfig.EntropyThreshold = 100.0
 
 			got := ScanAndRedact(tt.input)
-			
+
 			// CHANGED: Use Regex to verify output because Hash is dynamic/random if salt is random
 			// We expect [HIDDEN:Name:Hash] or [HIDDEN:Hash]
 			// The original expectedOutput in struct is just the prefix part for simplicity, OR we update the struct to be a regex.
 			// Let's treat tt.expectedOutput as a REGEX pattern now.
-			
+
 			matched, err := regexp.MatchString(tt.expectedOutput, got)
 			if err != nil {
 				t.Fatalf("Invalid regex in test case: %v", err)
@@ -106,7 +106,6 @@ func TestScanner_CustomRegexRedaction(t *testing.T) {
 		})
 	}
 }
-
 
 func TestScanner_CrashOnInvalidConfig(t *testing.T) {
 	t.Skip("Skipping subprocess test to avoid hanging during current session")

--- a/pkg/scanner/safety_coverage_test.go
+++ b/pkg/scanner/safety_coverage_test.go
@@ -7,21 +7,21 @@ import (
 
 func TestSafetyHeuristics(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         string
-		checkFunc     func(string) bool
-		expected      bool
+		name      string
+		input     string
+		checkFunc func(string) bool
+		expected  bool
 	}{
 		{"isImage_docker", "docker.io/library/nginx", isImage, true},
 		{"isImage_gcr", "gcr.io/google-containers/pause:3.2", isImage, true},
 		{"isImage_quay", "quay.io/coreos/etcd", isImage, true},
 		{"isImage_false", "just_a_normal_string", isImage, false},
-		
+
 		{"isGeneratedUsername_valid", "user_1a2b3c", isGeneratedUsername, true},
 		{"isGeneratedUsername_invalidChars", "user_1a2b*3c", isGeneratedUsername, false},
 		{"isGeneratedUsername_tooLong", "user_12345678901234", isGeneratedUsername, false},
 		{"isGeneratedUsername_false", "admin", isGeneratedUsername, false},
-		
+
 		{"isIPv6_valid", "2001:0db8:85a3:0000:0000:8a2e:0370:7334", isIPv6, true},
 		{"isIPv6_invalidChars", "2001:0db8::xz", isIPv6, false},
 		{"isIPv6_false", "192.168.1.1", isIPv6, false},
@@ -46,24 +46,24 @@ func TestSafetyHeuristics(t *testing.T) {
 func TestProcessEqualPairEdgeCases(t *testing.T) {
 	// Helper string builder for tests
 	var sb strings.Builder
-	
+
 	// Test normal assignment
 	isKey, _ := processEqualPair("config=safevalue", false, false, &sb)
 	if isKey {
 		t.Errorf("Expected config=safevalue not to be treated as a sensitive key")
 	}
-	
+
 	sb.Reset()
-	
+
 	// Test quoted assignment
 	sb.Reset()
 	_, _ = processEqualPair(`"password=mysecret"`, false, false, &sb)
 	if !strings.Contains(sb.String(), "[HIDDEN") {
 		t.Errorf("Expected quoted password assignment to be identified as sensitive and redacted, got: %s", sb.String())
 	}
-	
+
 	sb.Reset()
-	
+
 	// Test nested assignment (data=key=val)
 	_, handled := processEqualPair("data=config=safevalue", false, false, &sb)
 	if !handled {

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -528,12 +528,16 @@ func scanLine(logLine string, sb *strings.Builder) {
 		return
 	}
 
-	trimmed := strings.TrimSpace(logLine)
+	// TODO: verify if needed or can be removed
+	/*
+		trimmed := strings.TrimSpace(logLine)
 
-	// URL Optimization
-	if strings.HasPrefix(trimmed, "GET ") || strings.HasPrefix(trimmed, "POST ") || strings.Contains(trimmed, "://") {
-		// Rely on scanSegment
-	}
+		// URL Optimization
+
+		if strings.HasPrefix(trimmed, "GET ") || strings.HasPrefix(trimmed, "POST ") || strings.Contains(trimmed, "://") {
+			// Rely on scanSegment
+		}
+	*/
 
 	// OPTIMIZATION PHASE 3: Disable processJSONLine
 	// Standard JSON parsing is too slow. Our tokenizer handles JSON structure (quotes, braces) naturally.

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1202,7 +1202,7 @@ func isIPv6(token string) bool {
 	if strings.Count(token, ":") >= 2 {
 		isIPv6 := true
 		for _, r := range token {
-			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') || r == ':') {
+			if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') && r != ':' {
 				isIPv6 = false
 				break
 			}
@@ -1261,7 +1261,7 @@ func isSSHKey(token string) bool {
 		// Minimal Base64 check (just charset)
 		isBase64 := true
 		for _, r := range token {
-			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '+' || r == '/' || r == '=') {
+			if (r < '0' || r > '9') && (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && r != '+' && r != '/' && r != '=' {
 				isBase64 = false
 				break
 			}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1493,24 +1493,6 @@ func isDigits(s string) bool {
 	return true
 }
 
-func isUUID(s string) bool {
-	if len(s) != 36 {
-		return false
-	}
-	if s[8] != '-' || s[13] != '-' || s[18] != '-' || s[23] != '-' {
-		return false
-	}
-	for i, r := range s {
-		if i == 8 || i == 13 || i == 18 || i == 23 {
-			continue
-		}
-		if !isHex(r) {
-			return false
-		}
-	}
-	return true
-}
-
 func isHex(r rune) bool {
 	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
 }

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -21,7 +21,7 @@ import (
 // Config holds scanner configuration parameters.
 type Config struct {
 	EntropyThreshold        float64
-	ConfidenceThreshold     float64  // Hybrid validation confidence
+	ConfidenceThreshold     float64 // Hybrid validation confidence
 	MinSecretLength         int
 	Salt                    []byte
 	SensitiveKeys           []string
@@ -32,8 +32,8 @@ type Config struct {
 	AdaptiveBaselineSamples int      // Number of samples for adaptive baseline
 	CustomRegexes           []CustomRegexRule
 	SafeRegexes             []CustomRegexRule
-	CombinedCustomRegex     *regexp.Regexp    // Optimized "Mega-Regex" (O(1) match)
-	CustomRegexNames        []string          // Names corresponding to CombinedCustomRegex submatches
+	CombinedCustomRegex     *regexp.Regexp // Optimized "Mega-Regex" (O(1) match)
+	CustomRegexNames        []string       // Names corresponding to CombinedCustomRegex submatches
 }
 
 // CustomRegexConfig is the DTO for JSON unmarshalling from environment variables.
@@ -126,13 +126,13 @@ func parseInt(s string) (int, error) {
 
 func loadConfig() Config {
 	cfg := Config{
-		EntropyThreshold:        DefaultEntropyThreshold,   // Adjusted for bigrams
-		ConfidenceThreshold:     1.0,   // High confidence required to skip false positives
-		MinSecretLength:         6,     // Lower minimal length as we have better context
-		DisableBigramCheck:      false, // Enable bigram check by default
-		BigramDefaultScore:      -7.0,  // Default for unknown bigrams
-		AdaptiveThreshold:       false, // Disabled by default (User feedback)
-		AdaptiveBaselineSamples: 100,   // Default baseline sample size
+		EntropyThreshold:        DefaultEntropyThreshold, // Adjusted for bigrams
+		ConfidenceThreshold:     1.0,                     // High confidence required to skip false positives
+		MinSecretLength:         6,                       // Lower minimal length as we have better context
+		DisableBigramCheck:      false,                   // Enable bigram check by default
+		BigramDefaultScore:      -7.0,                    // Default for unknown bigrams
+		AdaptiveThreshold:       false,                   // Disabled by default (User feedback)
+		AdaptiveBaselineSamples: 100,                     // Default baseline sample size
 	}
 
 	// Load Salt - CRITICAL SECURITY: Try secure, fallback to error log (don't panic library)
@@ -238,11 +238,11 @@ func loadConfig() Config {
 			if _, err := regexp.Compile(rule.Pattern); err != nil {
 				log.Fatalf("PII_CUSTOM_REGEX_LIST error: invalid regex '%s': %v", rule.Pattern, err)
 			}
-			
+
 			// Add to combined list - wrapped in capturing group to identify which one matched
 			patterns = append(patterns, "("+rule.Pattern+")")
 			names = append(names, rule.Name)
-			
+
 			// Keep individual rules for backward compatibility (or remove if fully fully switched)
 			// processSingleToken uses CombinedCustomRegex now.
 			// existing tests might check cfg.CustomRegexes?
@@ -461,7 +461,7 @@ func redactWithHMAC(sensitiveData string, name string, strategy string, sb *stri
 
 	mac.Reset()
 	mac.Write([]byte(sensitiveData))
-	
+
 	// Zero-allocation hex encoding using stack buffer
 	var buf [32]byte
 	sum := mac.Sum(buf[:0])
@@ -477,13 +477,13 @@ func redactWithHMAC(sensitiveData string, name string, strategy string, sb *stri
 
 	// Separator for hash
 	sb.WriteRune(':')
-	
+
 	// Hex encode first 3 bytes (6 chars) directly to builder
 	// We can manually hex encode to avoid string conv
 	dst := make([]byte, 6)
 	hex.Encode(dst, sum[:3])
 	sb.Write(dst)
-	
+
 	sb.WriteString("]")
 }
 
@@ -539,12 +539,12 @@ func scanLine(logLine string, sb *strings.Builder) {
 	// Standard JSON parsing is too slow. Our tokenizer handles JSON structure (quotes, braces) naturally.
 	// This removes the map[string]interface{} boxing overhead.
 	/*
-	if strings.HasPrefix(trimmed, "{") {
-		if jsonProcessed, ok := processJSONLine(trimmed); ok {
-			sb.WriteString(jsonProcessed)
-			return
+		if strings.HasPrefix(trimmed, "{") {
+			if jsonProcessed, ok := processJSONLine(trimmed); ok {
+				sb.WriteString(jsonProcessed)
+				return
+			}
 		}
-	}
 	*/
 
 	luhnRanges := FindLuhnSequences(logLine)
@@ -696,8 +696,8 @@ func processTokenLogic(rawToken string, forcedSensitive bool, contextSensitive b
 		}
 	} else {
 		// Optimization Phase 3 Regression Fix:
-		// If we are in a Value position, and the value is a quoted string, 
-		// we must "unwrap" it and scan the specific content for embedded secrets 
+		// If we are in a Value position, and the value is a quoted string,
+		// we must "unwrap" it and scan the specific content for embedded secrets
 		// (e.g. JSON fields containing long error messages or nested structures).
 		// We only do this if NOT forcedSensitive (if forced, we redact the whole thing anyway).
 		if !forcedSensitive && len(rawToken) >= 2 {
@@ -789,20 +789,20 @@ func processSingleToken(content, original string, forcedSensitive bool, contextS
 				if needsQuotes {
 					sb.WriteRune('"')
 				}
-				
+
 				// Use hashed redaction for Custom Regex
 				redactWithHMAC(content, matchName, "regex", sb)
-				
+
 				if needsQuotes {
 					sb.WriteRune('"')
 				}
 				return
 			}
 		} else {
-             // ... fallback ...
+			// ... fallback ...
 			for _, rule := range currentConfig.CustomRegexes {
 				if rule.Regexp.MatchString(content) {
-                    					// ... redaction ...
+					// ... redaction ...
 					needsQuotes := false
 					if strings.HasPrefix(original, "\"") || strings.HasPrefix(original, "'") {
 						needsQuotes = true
@@ -816,10 +816,10 @@ func processSingleToken(content, original string, forcedSensitive bool, contextS
 					if needsQuotes {
 						sb.WriteRune('"')
 					}
-					
+
 					// Use hashed redaction for Custom Regex
 					redactWithHMAC(content, rule.Name, "regex", sb)
-					
+
 					if needsQuotes {
 						sb.WriteRune('"')
 					}
@@ -960,19 +960,19 @@ func processEqualPair(rawToken string, forcedSensitive bool, overrideSensitivity
 		// Unquoted Key=Value
 		key := rawToken[:idx] // Up to =
 		val := rawToken[idx+1:]
-		
+
 		keySensitive := isSensitiveKey(key) || overrideSensitivity
 
 		sb.WriteString(key)
 		sb.WriteRune('=')
-		
+
 		if containsSep := strings.Contains(val, "=") || strings.Contains(val, ":"); containsSep && !keySensitive {
 			// Recursive handling for "data=key=val" where "data" is safe.
 			processTokenLogic(val, false, false, false, overrideSensitivity, sb)
 		} else {
 			processSingleToken(val, val, keySensitive, false, false, sb)
 		}
-		
+
 		return keySensitive && val == "", true
 	}
 	return false, false
@@ -985,7 +985,7 @@ func processColonPair(rawToken string, overrideSensitivity bool, sb *strings.Bui
 	// Fix: Only split on colon if it's NOT inside quotes
 	// e.g. "Error: msg" -> Should NOT split
 	// "key": val -> Should split (colon after quote)
-	
+
 	idx := -1
 	if strings.HasPrefix(rawToken, "\"") || strings.HasPrefix(rawToken, "'") {
 		// Quoted token: Find end quote
@@ -1002,7 +1002,7 @@ func processColonPair(rawToken string, overrideSensitivity bool, sb *strings.Bui
 				idx = realEnd + 1 + colIdx
 			}
 		} else {
-			// Unbalanced or strict string? Fallback to normal index? 
+			// Unbalanced or strict string? Fallback to normal index?
 			// If unbalanced, treat as normal string.
 			idx = strings.IndexByte(rawToken, ':')
 		}
@@ -1015,10 +1015,10 @@ func processColonPair(rawToken string, overrideSensitivity bool, sb *strings.Bui
 			sb.WriteString(rawToken)
 			return false, true
 		}
-		
+
 		keyRaw := rawToken[:idx]
 		val := rawToken[idx+1:]
-		
+
 		key := trimQuotes(keyRaw)
 		keySensitive := isSensitiveKey(key) || overrideSensitivity
 
@@ -1027,11 +1027,11 @@ func processColonPair(rawToken string, overrideSensitivity bool, sb *strings.Bui
 			sb.WriteString(rawToken)
 			return keySensitive, true
 		}
-		
+
 		sb.WriteString(keyRaw) // Write original key (with quotes)
 		sb.WriteRune(':')
 		processSingleToken(val, val, keySensitive, false, false, sb)
-		
+
 		return keySensitive, true
 	}
 	return false, false
@@ -1320,7 +1320,7 @@ func FindLuhnSequences(line string) []Range {
 	// Optimization: Use sync.Pool for digitIndices to avoid allocation per line
 	digitIndicesPtr := luhnPool.Get().(*[]int)
 	defer luhnPool.Put(digitIndicesPtr)
-	
+
 	// Reset slice length to 0, keep capacity
 	digitIndices := (*digitIndicesPtr)[:0]
 
@@ -1656,10 +1656,10 @@ type segmentState struct {
 	pendingKeySensitive     bool
 	pendingContextSensitive bool // NEW: For "Error: secret"
 	isInValuePos            bool // Tracks if we are physically after a ':' or '=' separator
-	
+
 	// Generic KV Support
-	pendingGenericKey       bool // True if last key was "key", "name"
-	nextValueIsSensitive    bool // True if "key"="password", so next "value" is sensitive
+	pendingGenericKey    bool // True if last key was "key", "name"
+	nextValueIsSensitive bool // True if "key"="password", so next "value" is sensitive
 }
 
 func processAndAppend(token string, sb *strings.Builder, state *segmentState) {
@@ -1672,10 +1672,10 @@ func processAndAppend(token string, sb *strings.Builder, state *segmentState) {
 	}
 	cleanToken = trimQuotes(cleanToken)
 	lowerClean := strings.ToLower(cleanToken)
-	
+
 	// Check if this token is a "Generic Key" identifier (e.g. "key", "name")
 	isGenericKeyName := lowerClean == "key" || lowerClean == "name" || lowerClean == "setting"
-	
+
 	// 1. Process Token
 	isKey := processTokenLogic(token, state.pendingKeySensitive, state.pendingContextSensitive, state.isInValuePos, state.nextValueIsSensitive, sb)
 	// sb is updated inside processTokenLogic
@@ -1685,7 +1685,7 @@ func processAndAppend(token string, sb *strings.Builder, state *segmentState) {
 		state.pendingKeySensitive = true // Next token (value) will be redacted
 		// Reset expectation since we found the key
 		state.nextValueIsSensitive = false
-		
+
 		if isGenericKeyName {
 			state.pendingGenericKey = true
 		} else {
@@ -1695,7 +1695,7 @@ func processAndAppend(token string, sb *strings.Builder, state *segmentState) {
 		// Value Position
 		if state.isInValuePos {
 			state.pendingKeySensitive = false
-			
+
 			// If we were waiting for the value of a Generic Key...
 			if state.pendingGenericKey {
 				// Check if THIS value is a sensitive key name (e.g. "password")

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -82,11 +82,11 @@ func TestScanner_NegativeCases(t *testing.T) {
 		input        string
 		shouldRedact bool
 	}{
-		{"Weak Password", "password=123", true},                     // Should be redacted because key 'password' is sensitive
-		{"Common Word", "key=value", true},                          // Should be redacted because key 'key' is sensitive
-		{"High Entropy Secret", "api_key=sk_live_51Nc7qE...", true}, // Should be redacted
-		{"Random Noise", "data=8f7d9a2b3c4e5f6", true},              // High entropy hex
-		{"Valid Visa (Luhn)", "cc=4556737586899855", true},          // Valid Luhn with enough distinct digits (7 > 4)
+		{"Weak Password", "password=123", true},                                                       // Should be redacted because key 'password' is sensitive
+		{"Common Word", "key=value", true},                                                            // Should be redacted because key 'key' is sensitive
+		{"High Entropy Secret", "api_key=sk_live_51Nc7qE...", true},                                   // Should be redacted
+		{"Random Noise", "data=8f7d9a2b3c4e5f6", true},                                                // High entropy hex
+		{"Valid Visa (Luhn)", "cc=4556737586899855", true},                                            // Valid Luhn with enough distinct digits (7 > 4)
 		{"Stress Test Leak (ccGazanojgGcOSa)", "Error: 192.168.1.5 ccGazanojgGcOSa connection", true}, // Regression test for Threshold 3.6
 	}
 

--- a/pkg/scanner/windows_path_test.go
+++ b/pkg/scanner/windows_path_test.go
@@ -7,12 +7,12 @@ import (
 func TestReproWindowsPathRedaction(t *testing.T) {
 	// The log line reported by the user
 	line := `2026-02-08 20:07:02: Running - app\modules\adaptive\jobs\TestingInstanceJob`
-	
+
 	// We expect it NOT to be redacted.
 	// Current behavior according to user: `2026-02-08 20:07:02: Running - [HIDDEN:f329a5]`
-	
+
 	processed := ScanAndRedact(line)
-	
+
 	if processed != line {
 		t.Errorf("Expected no redaction, but got:\n%s\nOriginal:\n%s", processed, line)
 	}


### PR DESCRIPTION
## Summary

This PR adds `golangci-lint` integration and applies formatting/lint cleanup across the repository.

## Changes

* Added `.golangci.yml` configuration with:

  * default linters
  * `gofmt` integration
* Temporarily disabled `errcheck` for test files
* Applied `gofmt` across the repository
* Fixed several lint issues reported by `golangci-lint`
* Removed unused `isUUID` from `pkg/scanner/scanner.go`

  * this helper was unused and could affect issue #35

## Notes

I noticed there is already a separate `.golangci.yml` under `operator/`, so I did not modify it in this PR.
