### PR TITLE
Prepare 2.0.2 stabilization release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
     - name: Run Tests (Race & Coverage)
       run: go test -race -coverprofile=coverage.out ./...
 
+    - name: Run Operator Tests
+      working-directory: operator
+      run: go test -v -race -coverprofile=cover.out ./...
+
     - name: Check Coverage Threshold
       run: |
         go tool cover -func=coverage.out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,10 @@ jobs:
     - name: Run Tests with Coverage
       run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
+    - name: Run Operator Tests
+      working-directory: operator
+      run: go test -v -race -coverprofile=cover.out ./...
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Binaries
 # Binaries built by go build or scripts
 /pii-shield
-cleaner
+/cleaner
 *.exe
 *.exe~
 *.dll
@@ -35,15 +35,32 @@ Thumbs.db
 .vscode/
 *.iml
 
-# Logs
+# Logs and local scratch files
 *.log
 *.tmp
-cleaner
-docs
-buiild.sh
-public
+
+# Local build/cache artifacts
+.gocache/
+operator/manager
+operator/cover.out
+
+# Published landing page source/assets are maintained outside the core repo
+public/
+
+# Browser WASM demo source is maintained with the landing page, not the core repo
 cmd/wasm/
-pkg/scanner/regex_redaction_test.go
+
+# Draft/published article workspace is maintained outside the core repo
+docs/
+
+# Local OpenSpec workspace is maintained outside the core repo
+openspec/
+
+# Local release helper
 release.sh
-openspec/*
-.agent
+
+# Local automation scratch space
+.agent/
+
+# Local build binary
+build.sh

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -1,0 +1,24 @@
+# Known Limitations
+
+PII-Shield is an active MVP/Beta project. The current codebase validates the core redaction approach, but production compliance deployments should account for the boundaries below.
+
+## Kubernetes Logging
+
+- The default file-based sidecar mode expects the application to write logs to the configured file path.
+- Full transparent interception of standard Kubernetes `stdout`/`stderr` logs is not complete yet.
+- Pipe mode changes the target container command and should be tested carefully before production use.
+
+## Operator
+
+- The Kubernetes operator is in stabilization. It supports policy objects and webhook injection, but advanced policy lifecycle management is still evolving.
+- eBPF mode is experimental/R&D and should not be treated as production-ready interception.
+
+## Scanner Configuration
+
+- Set a persistent `PII_SALT` in production if deterministic hashes must remain stable across restarts.
+- Adaptive entropy thresholding is experimental and should be validated against representative log traffic before enabling.
+- Custom regex and safe regex rules should be tested with real log samples to avoid false positives or false negatives.
+
+## Roadmap Boundaries
+
+Proxy-Wasm gateway integration, a visual Control Plane, and production-grade eBPF interception are planned R&D areas rather than completed stable features.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Prevents data leaks (GDPR/SOC2) by redacting PII from logs *before* they leave t
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/pii-shield)](https://artifacthub.io/packages/search?repo=pii-shield)
 ![PyPI Downloads](https://img.shields.io/pypi/dm/pii-shield-wasi?label=PyPI%20Downloads&color=blue)
 ![npm Downloads](https://img.shields.io/npm/dw/@aragossa/pii-shield-wasi?label=npm%20Downloads&color=green)
+[![Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/pii-shield)
 
 "Don't let PII poison your AI models." PII-Shield ensures that sensitive data never reaches your training dataset, saving you from GDPR-forced model retraining.
 
@@ -27,15 +28,31 @@ PII-Shield offers two distinct ways to integrate into your stack:
 1. **Kubernetes Operator (Zero-code)**: Our flagship deployment model. A fully automated K8s Operator that injects a highly-secure Distroless Sidecar into your pods to intercept and sanitize logs on the fly.
 2. **In-Process WASM (For core integrations)**: For extreme performance, the core engine can be embedded directly via WASM, providing `<1ms` latency without network hops.
 
+## Project Status & Roadmap
+
+PII-Shield is an active open-source MVP moving through production hardening. The core scanner and CLI sidecar are usable for local streams and controlled deployments, while the Kubernetes operator and SDK surfaces are in beta stabilization.
+
+| Component | Status |
+| --- | --- |
+| Core scanner | Active MVP / Beta |
+| CLI sidecar | Beta |
+| Kubernetes operator | Stabilization phase |
+| WASM SDKs | Beta |
+| Proxy-Wasm gateway integration | Planned R&D |
+| Control Plane UI | Planned R&D |
+| eBPF interception | Planned R&D |
+
+See [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md) for the current production-hardening boundaries.
+
 ## Why PII-Shield?
 
 Developers often forget to mask sensitive data. Traditional regex filters in Fluentd/Logstash are slow, hard to maintain, and consume expensive CPU on log aggregators.
 
 **PII-Shield sits right next to your app container:**
-- **Production Ready:** Optimized for Kubernetes sidecars with **ultra-low memory allocations** (zero-GC overhead on hot paths) and deterministic O(1) regex matching.
+- **Beta Core Engine:** Optimized for Kubernetes sidecars with low memory allocations on hot paths and deterministic regex matching.
 - **Context-Aware Entropy Analysis:** Detected high-entropy secrets even without keys (e.g. `Error: ... 44saCk9...`) by analyzing context keywords.
-- **Custom Regex Rules:** Deterministic redaction for structured data (UUIDs, IDs) that overrides entropy checks, ensuring 100% compliance for known patterns.
-- **100% Accuracy:** Verified against "Wild" stress tests including binary garbage, JSON nesting, and multilingual logs.
+- **Custom Regex Rules:** Deterministic redaction for structured data (UUIDs, IDs) that overrides entropy checks for known patterns.
+- **Regression & Fuzz Coverage:** Tested against stress cases including binary garbage, JSON nesting, and multilingual logs.
 - **Deterministic Hashing:** Replaces secrets with unique hashes (e.g., `[HIDDEN:a1b2c]`), allowing QA to correlate errors without seeing the raw data.
 - **Drop-in:** No code changes required. Works with any language (Node, Python, Java, Go).
 - **Whitelist Support:** Explicitly allow safe patterns (e.g., git hashes, system IDs) using `PII_SAFE_REGEX_LIST` to prevent false positives.
@@ -73,9 +90,9 @@ This deploys the PII-Shield Operator which automatically injects highly-secure, 
 ### Docker
 Get the latest lightweight image from Docker Hub or GHCR:
 ```bash
-docker pull thelisdeep/pii-shield:v2.0.0
+docker pull thelisdeep/pii-shield:v2.0.2
 # OR from GitHub Container Registry (Enterprise):
-docker pull ghcr.io/pii-shield/pii-shield:v2.0.0
+docker pull ghcr.io/pii-shield/pii-shield:v2.0.2
 ```
 
 ### Build from Source
@@ -110,7 +127,7 @@ You can pipe any log output through PII-Shield to see it in action immediately:
 
 ```bash
 # Emulate a log with a sensitive password
-echo "Error: User password=MySecretPass123! failed login" | docker run -i --rm ghcr.io/pii-shield/pii-shield:v2.0.0
+echo "Error: User password=MySecretPass123! failed login" | docker run -i --rm ghcr.io/pii-shield/pii-shield:v2.0.2
 
 # Output: Error: User password=[HIDDEN:8f3a11] failed login
 ```
@@ -148,11 +165,32 @@ spec:
 The Operator will automatically inject the `pii-shield-agent` using the Native Sidecar pattern (K8s 1.28+) and securely mask all logs!
 
 ## Verification
-This project is verified with a comprehensive testing suite, ensuring production-readiness for v2.0.0:
+This project is verified with a growing testing suite intended to raise confidence before production hardening:
 1. **Unit Tests**: Cover edge cases, multilingual support, and JSON integrity with >85% coverage.
 2. **Fuzzing**: Native Go fuzzing ensures crash safety against invalid and random binary inputs.
-3. **Smoke Testing**: `./run_smoke.sh` validates 100% detection accuracy on mixed workloads.
+3. **Smoke Testing**: `./run_smoke.sh` exercises mixed workloads and reports detection accuracy.
 4. **End-to-End (E2E) Testing**: The `operator/tests/run_e2e.sh` suite performs full-stack validation using Minikube and Helm. It builds local images, provisions the Operator without cert-manager, deploys target Jobs, and verifies actual log redaction by intercepting sidecar outputs.
+
+### Operator Integration Tests
+
+The operator keeps fast unit tests separate from Kubernetes API integration tests. Regular operator tests do not start a local API server:
+
+```bash
+cd operator
+go test ./...
+```
+
+To run the envtest-based controller integration suite:
+
+```bash
+./run_operator_integration.sh
+```
+
+These tests start a local Kubernetes API server and etcd through `envtest`, so they require permission to bind to `127.0.0.1`. In restricted sandboxes, run them in a local shell, Docker environment, or CI runner that allows localhost bind.
+
+## Support
+
+PII-Shield is open-source infrastructure for privacy-preserving logs. If this project is useful to you or your organization, you can support its development through [GitHub Sponsors](https://github.com/sponsors/pii-shield).
 
 ## License
 Distributed under the Apache 2.0 License. See `LICENSE` for more information.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+PII-Shield is currently in beta stabilization. Please treat security-sensitive deployments as controlled rollouts and validate policies against representative logs before production use.
+
+## Reporting Security Issues
+
+Please report security issues privately to the maintainer at ilya.ploskovitov@pii-shield.com. Include the affected component, reproduction steps, expected behavior, and any relevant logs or policy snippets.
+
+## Supported Versions
+
+The `main` branch is the active development line. Tagged releases should be evaluated with the documented limitations in [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md).
+
+## Deployment Guidance
+
+- Configure a persistent `PII_SALT` for production deployments.
+- Test custom redaction and whitelist rules before rollout.
+- Review Kubernetes webhook behavior and failure policy for your compliance requirements.
+- Treat eBPF and advanced gateway interception modes as R&D until explicitly marked stable.

--- a/charts/pii-shield-operator/Chart.yaml
+++ b/charts/pii-shield-operator/Chart.yaml
@@ -4,9 +4,9 @@ description: A Kubernetes Operator for automatic PII (Personally Identifiable In
 
 type: application
 
-version: 2.0.0
+version: 2.0.2
 
-appVersion: "2.0.0"
+appVersion: "2.0.2"
 
 home: https://github.com/pii-shield/pii-shield
 sources:

--- a/charts/pii-shield/Chart.yaml
+++ b/charts/pii-shield/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pii-shield
 description: A Helm chart for deploying PII-Shield as a demonstrational logging sidecar
 type: application
-version: 2.0.1
-appVersion: "2.0.1"
+version: 2.0.2
+appVersion: "2.0.2"
 
 annotations:
   artifacthub.io/official: "true"

--- a/charts/pii-shield/values.yaml
+++ b/charts/pii-shield/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: thelisdeep/pii-shield
   pullPolicy: IfNotPresent
-  tag: "2.0.0"
+  tag: "2.0.2"
 
 generatorImage:
   repository: alpine

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/pii-shield/pii-shield
 
 go 1.26
 
-require github.com/prometheus/client_golang v1.23.2
+require (
+	github.com/nxadm/tail v1.4.11
+	github.com/prometheus/client_golang v1.23.2
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -11,7 +14,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/operator/api/v1alpha1/piipolicy_types.go
+++ b/operator/api/v1alpha1/piipolicy_types.go
@@ -21,9 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // PiiPolicySpec defines the desired state of PiiPolicy
 type PiiPolicySpec struct {
 	// FailPolicy determines the behavior on failure
@@ -49,12 +46,6 @@ type PiiPolicySpec struct {
 
 // PiiPolicyStatus defines the observed state of PiiPolicy.
 type PiiPolicyStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// For Kubernetes API conventions, see:
-	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
-
 	// conditions represent the current state of the PiiPolicy resource.
 	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
 	//

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -4,7 +4,6 @@ go 1.25.3
 
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2
-	github.com/onsi/gomega v1.38.2
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
@@ -48,6 +47,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/onsi/gomega v1.38.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/operator/internal/controller/piipolicy_controller.go
+++ b/operator/internal/controller/piipolicy_controller.go
@@ -18,7 +18,11 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,19 +41,47 @@ type PiiPolicyReconciler struct {
 // +kubebuilder:rbac:groups=core.pii-shield.io,resources=piipolicies/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core.pii-shield.io,resources=piipolicies/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the PiiPolicy object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/reconcile
+// Reconcile validates a PiiPolicy enough to expose an auditable status without
+// mutating the user's desired spec.
 func (r *PiiPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = logf.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
-	// TODO(user): your logic here
+	policy := &corev1alpha1.PiiPolicy{}
+	if err := r.Get(ctx, req.NamespacedName, policy); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	effectiveMode := policy.Spec.InjectionMode
+	if effectiveMode == "" {
+		effectiveMode = "file"
+	}
+
+	condition := metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionTrue,
+		Reason:             "PolicyAccepted",
+		Message:            fmt.Sprintf("Policy is accepted. Effective injection mode: %s", effectiveMode),
+		ObservedGeneration: policy.Generation,
+	}
+
+	switch effectiveMode {
+	case "file", "pipe", "ebpf":
+	default:
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = "InvalidInjectionMode"
+		condition.Message = fmt.Sprintf("Unsupported injection mode: %s", effectiveMode)
+	}
+
+	oldConditions := append([]metav1.Condition(nil), policy.Status.Conditions...)
+	meta.SetStatusCondition(&policy.Status.Conditions, condition)
+	if reflect.DeepEqual(oldConditions, policy.Status.Conditions) {
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.Status().Update(ctx, policy); err != nil {
+		log.Error(err, "failed to update PiiPolicy status")
+		return ctrl.Result{}, err
+	}
 
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/piipolicy_controller_integration_test.go
+++ b/operator/internal/controller/piipolicy_controller_integration_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1alpha1 "github.com/pii-shield/pii-shield/operator/api/v1alpha1"
+)
+
+var _ = Describe("PiiPolicy Controller integration", func() {
+	const resourceName = "test-resource"
+
+	ctx := context.Background()
+	typeNamespacedName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: "default",
+	}
+
+	AfterEach(func() {
+		resource := &corev1alpha1.PiiPolicy{}
+		err := k8sClient.Get(ctx, typeNamespacedName, resource)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		}
+	})
+
+	It("sets Available status for an accepted policy", func() {
+		resource := &corev1alpha1.PiiPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: "default",
+			},
+			Spec: corev1alpha1.PiiPolicySpec{
+				InjectionMode: "file",
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+		controllerReconciler := &PiiPolicyReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &corev1alpha1.PiiPolicy{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+		condition := meta.FindStatusCondition(updated.Status.Conditions, "Available")
+		Expect(condition).NotTo(BeNil())
+		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(condition.Reason).To(Equal("PolicyAccepted"))
+	})
+})

--- a/operator/internal/controller/piipolicy_controller_test.go
+++ b/operator/internal/controller/piipolicy_controller_test.go
@@ -1,86 +1,167 @@
-/*
-Copyright 2026.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package controller
 
 import (
 	"context"
+	"strings"
+	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1alpha1 "github.com/pii-shield/pii-shield/operator/api/v1alpha1"
 )
 
-var _ = Describe("PiiPolicy Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+func TestPiiPolicyReconcileSetsAvailableCondition(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+	policy := &corev1alpha1.PiiPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "strict-policy",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: corev1alpha1.PiiPolicySpec{
+			InjectionMode: "file",
+		},
+	}
+	reconciler := newTestReconciler(t, scheme, policy)
 
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		piipolicy := &corev1alpha1.PiiPolicy{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind PiiPolicy")
-			err := k8sClient.Get(ctx, typeNamespacedName, piipolicy)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &corev1alpha1.PiiPolicy{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					Spec: corev1alpha1.PiiPolicySpec{
-						InjectionMode: "file",
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &corev1alpha1.PiiPolicy{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance PiiPolicy")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &PiiPolicyReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
-		})
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace},
 	})
-})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	got := fetchPolicy(t, ctx, reconciler, policy.Name, policy.Namespace)
+	cond := meta.FindStatusCondition(got.Status.Conditions, "Available")
+	if cond == nil {
+		t.Fatalf("expected Available condition, got none")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Available=True, got %s: %s", cond.Status, cond.Message)
+	}
+	if cond.Reason != "PolicyAccepted" {
+		t.Fatalf("expected PolicyAccepted reason, got %q", cond.Reason)
+	}
+	if cond.ObservedGeneration != policy.Generation {
+		t.Fatalf("expected observed generation %d, got %d", policy.Generation, cond.ObservedGeneration)
+	}
+}
+
+func TestPiiPolicyReconcileUsesDefaultModeWithoutMutatingSpec(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+	policy := &corev1alpha1.PiiPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "defaulted-policy",
+			Namespace: "default",
+		},
+	}
+	reconciler := newTestReconciler(t, scheme, policy)
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	got := fetchPolicy(t, ctx, reconciler, policy.Name, policy.Namespace)
+	if got.Spec.InjectionMode != "" {
+		t.Fatalf("expected spec injectionMode to remain empty, got %q", got.Spec.InjectionMode)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, "Available")
+	if cond == nil {
+		t.Fatalf("expected Available condition, got none")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Available=True, got %s", cond.Status)
+	}
+	if !strings.Contains(cond.Message, "Effective injection mode: file") {
+		t.Fatalf("expected default file mode in message, got %q", cond.Message)
+	}
+}
+
+func TestPiiPolicyReconcileMarksUnknownModeUnavailable(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+	policy := &corev1alpha1.PiiPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bad-policy",
+			Namespace: "default",
+		},
+		Spec: corev1alpha1.PiiPolicySpec{
+			InjectionMode: "unknown",
+		},
+	}
+	reconciler := newTestReconciler(t, scheme, policy)
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	got := fetchPolicy(t, ctx, reconciler, policy.Name, policy.Namespace)
+	cond := meta.FindStatusCondition(got.Status.Conditions, "Available")
+	if cond == nil {
+		t.Fatalf("expected Available condition, got none")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected Available=False, got %s", cond.Status)
+	}
+	if cond.Reason != "InvalidInjectionMode" {
+		t.Fatalf("expected InvalidInjectionMode reason, got %q", cond.Reason)
+	}
+}
+
+func TestPiiPolicyReconcileIgnoresNotFound(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+	reconciler := newTestReconciler(t, scheme)
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "missing", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("expected NotFound to be ignored, got %v", err)
+	}
+}
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add PiiPolicy scheme: %v", err)
+	}
+	return scheme
+}
+
+func newTestReconciler(t *testing.T, scheme *runtime.Scheme, objects ...runtime.Object) *PiiPolicyReconciler {
+	t.Helper()
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objects...).
+		WithStatusSubresource(&corev1alpha1.PiiPolicy{}).
+		Build()
+
+	return &PiiPolicyReconciler{
+		Client: client,
+		Scheme: scheme,
+	}
+}
+
+func fetchPolicy(t *testing.T, ctx context.Context, reconciler *PiiPolicyReconciler, name, namespace string) *corev1alpha1.PiiPolicy {
+	t.Helper()
+	policy := &corev1alpha1.PiiPolicy{}
+	if err := reconciler.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, policy); err != nil {
+		t.Fatalf("failed to fetch policy: %v", err)
+	}
+	return policy
+}

--- a/operator/internal/controller/suite_test.go
+++ b/operator/internal/controller/suite_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
 Copyright 2026.
 
@@ -34,49 +36,39 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	corev1alpha1 "github.com/pii-shield/pii-shield/operator/api/v1alpha1"
-	// +kubebuilder:scaffold:imports
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	testEnv   *envtest.Environment
-	cfg       *rest.Config
-	k8sClient client.Client
+	integrationCtx    context.Context
+	integrationCancel context.CancelFunc
+	testEnv           *envtest.Environment
+	cfg               *rest.Config
+	k8sClient         client.Client
 )
 
-func TestControllers(t *testing.T) {
+func TestControllerIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	RunSpecs(t, "Controller Suite")
+	RunSpecs(t, "Controller Integration Suite")
 }
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	ctx, cancel = context.WithCancel(context.TODO())
+	integrationCtx, integrationCancel = context.WithCancel(context.TODO())
 
-	var err error
-	err = corev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(corev1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 
-	// +kubebuilder:scaffold:scheme
-
-	By("bootstrapping test environment")
+	By("bootstrapping envtest control plane")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
 
-	// Retrieve the first found binary directory to allow running tests from IDEs
-	if getFirstFoundEnvTestBinaryDir() != "" {
-		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	if binaryDir := getFirstFoundEnvTestBinaryDir(); binaryDir != "" {
+		testEnv.BinaryAssetsDirectory = binaryDir
 	}
 
-	// cfg is defined in this file globally.
+	var err error
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -87,26 +79,18 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
+	By("tearing down envtest control plane")
+	integrationCancel()
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())
 })
 
-// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
-// ENVTEST-based tests depend on specific binaries, usually located in paths set by
-// controller-runtime. When running tests directly (e.g., via an IDE) without using
-// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
-//
-// This function streamlines the process by finding the required binaries, similar to
-// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
-// properly set up, run 'make setup-envtest' beforehand.
 func getFirstFoundEnvTestBinaryDir() string {
 	basePath := filepath.Join("..", "..", "bin", "k8s")
 	entries, err := os.ReadDir(basePath)
 	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		logf.Log.Error(err, "Failed to read envtest binary directory", "path", basePath)
 		return ""
 	}
 	for _, entry := range entries {

--- a/operator/tests/run_e2e.sh
+++ b/operator/tests/run_e2e.sh
@@ -79,7 +79,7 @@ echo "🚀 Deploying test-job..."
 kubectl apply -f tests/test-job.yaml -n ${APP_NAMESPACE}
 
 # Wait for Job Pod to be created
-echo "⏳ Ожидание создания пода от Job..."
+echo "⏳ Waiting for the Job pod to be created..."
 while [[ $(kubectl get pods -l job-name=test-job -n ${APP_NAMESPACE} -o jsonpath='{.items}') == "[]" ]]; do
   sleep 1
 done
@@ -93,9 +93,9 @@ if ! kubectl wait --for=condition=ready pod -l job-name=test-job -n ${APP_NAMESP
   exit 1
 fi
 
-# Быстрая проверка на падение
+# Quick failure check
 if kubectl get pod -l job-name=test-job -n ${APP_NAMESPACE} -o jsonpath='{.items[0].status.phase}' | grep -q "Failed"; then
-  echo "❌ Ошибка: Pod завершился со статусом Failed"
+  echo "❌ Error: Pod finished with Failed status"
   kubectl describe pod -l job-name=test-job -n ${APP_NAMESPACE}
   exit 1
 fi
@@ -136,7 +136,7 @@ if [ "$SUCCESS_HIDDEN" = false ]; then
 fi
 
 if [ "$SUCCESS_SAFE" = false ]; then
-  echo "❌ Error: Ложное срабатывание: безопасные данные были повреждены или не найдены."
+  echo "❌ Error: False positive: safe data was modified or not found."
   echo "--- Sidecar Logs ---"
   kubectl logs -l job-name=test-job -c pii-shield-sidecar -n ${APP_NAMESPACE}
   exit 1

--- a/run_operator_integration.sh
+++ b/run_operator_integration.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPERATOR_DIR="${ROOT_DIR}/operator"
+
+if [ ! -d "${OPERATOR_DIR}" ]; then
+  echo "operator directory not found at ${OPERATOR_DIR}" >&2
+  exit 1
+fi
+
+export GOCACHE="${GOCACHE:-${ROOT_DIR}/.gocache}"
+
+echo "Running operator integration tests with envtest..."
+echo "Note: these tests start a local Kubernetes API server and require localhost bind permissions."
+
+cd "${OPERATOR_DIR}"
+go test -tags=integration ./internal/controller/...

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragossa/pii-shield-wasi",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "High-performance PII redaction scanner using Go WASM (WASI)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pii-shield-wasi"
-version = "2.0.1"
+version = "2.0.2"
 authors = [
   { name="Aragossa" },
 ]


### PR DESCRIPTION
- Added project status and roadmap positioning to `README.md`
- Added `KNOWN_LIMITATIONS.md` and `SECURITY.md`
- Added GitHub Sponsors badge and `Support` section
- Cleaned `.gitignore` rules for local/public-only workspaces and build artifacts
- Removed tracked `operator/manager` binary from the repository
- Added `//go:build js && wasm` to browser WASM code so root tests do not try to build `syscall/js`
- Added a minimal `PiiPolicy` reconciler status loop:
  - ignores `NotFound`
  - computes default `file` mode without mutating `spec`
  - writes `Available` conditions
  - marks unknown modes as unavailable
- Replaced regular controller tests with fast fake-client unit tests
- Preserved envtest coverage under the `integration` build tag
- Added `run_operator_integration.sh`
- Added operator test steps to GitHub Actions
- Translated remaining Russian code comments/messages to English, except intentional multilingual scanner test fixtures
- Bumped release metadata to `2.0.2`:
  - `charts/pii-shield/Chart.yaml`
  - `charts/pii-shield/values.yaml`
  - `charts/pii-shield-operator/Chart.yaml`
  - `sdks/node/package.json`
  - `sdks/python/pyproject.toml`
  - README Docker examples