### PR TITLE
Forward safe config fields through SDK/WASM and add cross-entrypoint parity tests (#48)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@
 *.so
 *.dylib
 
+# Compiled WASM FFI kernel (built fresh in CI, never committed)
+pii-shield-wasi.wasm
+
+# Python SDK bytecode cache
+__pycache__/
+*.pyc
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/cmd/wasm-ffi/main.go
+++ b/cmd/wasm-ffi/main.go
@@ -4,17 +4,25 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"unsafe"
 
 	"github.com/pii-shield/pii-shield/pkg/scanner"
 )
 
-// ConfigFromSDK represents configuration passed from Python/Node.js SDKs
+// ConfigFromSDK represents configuration passed from Python/Node.js SDKs.
+// Fields that require compiled/derived state (SensitiveKeyPatterns,
+// CustomRegexes, SafeRegexes) are intentionally NOT accepted here yet; see the
+// "Unsupported config fields" section in the SDK READMEs.
 type ConfigFromSDK struct {
-	EntropyThreshold    float64 `json:"entropy_threshold"`
-	Salt                string  `json:"salt"`
-	ConfidenceThreshold float64 `json:"confidence_score"`
-	FailPolicy          string  `json:"fail_policy"`
+	EntropyThreshold    float64  `json:"entropy_threshold"`
+	Salt                string   `json:"salt"`
+	ConfidenceThreshold float64  `json:"confidence_score"`
+	FailPolicy          string   `json:"fail_policy"`
+	MinSecretLength     int      `json:"min_secret_length"`
+	SensitiveKeys       []string `json:"sensitive_keys"`
+	DisableBigramCheck  *bool    `json:"disable_bigram_check"`
+	AdaptiveThreshold   *bool    `json:"adaptive_threshold"`
 }
 
 // We use a map to pin memory allocations. This prevents Go's Garbage Collector
@@ -65,9 +73,27 @@ func init_config(ptr uint32, length uint32) {
 		if sdkCfg.ConfidenceThreshold > 0 {
 			cfg.ConfidenceThreshold = sdkCfg.ConfidenceThreshold
 		}
-		// The package doesn't have an SDK property for fail policy yet, but we have it passed.
-		// Wait, package level fails are in cmd/cleaner not in scanner.Config. 
-		// If SDK wants to handle Fail-Closed vs Open, we can provide it downstream at SDK wrappers.
+		if sdkCfg.MinSecretLength > 0 {
+			cfg.MinSecretLength = sdkCfg.MinSecretLength
+		}
+		if len(sdkCfg.SensitiveKeys) > 0 {
+			// Normalize the same way loadConfig does for PII_SENSITIVE_KEYS so
+			// SDK-provided keys match the CLI's case-insensitive matching.
+			keys := make([]string, len(sdkCfg.SensitiveKeys))
+			for i, k := range sdkCfg.SensitiveKeys {
+				keys[i] = strings.ToLower(strings.TrimSpace(k))
+			}
+			cfg.SensitiveKeys = keys
+		}
+		if sdkCfg.DisableBigramCheck != nil {
+			cfg.DisableBigramCheck = *sdkCfg.DisableBigramCheck
+		}
+		if sdkCfg.AdaptiveThreshold != nil {
+			cfg.AdaptiveThreshold = *sdkCfg.AdaptiveThreshold
+		}
+		// Fail policy is handled in the SDK wrappers (Node/Python), not in
+		// scanner.Config. SensitiveKeyPatterns, CustomRegexes, and SafeRegexes
+		// require compiled state built in loadConfig and are not forwarded yet.
 	}
 
 	scanner.UpdateConfig(cfg)

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -1,6 +1,6 @@
 # @aragossa/pii-shield-wasi
 
-High-performance PII redaction scanner powered by a core Go engine compiled to WebAssembly (WASI). It provides lightning-fast text analysis with hybrid heuristic and entropy-based validation.
+PII redaction scanner powered by the core Go engine compiled to WebAssembly (WASI). It runs **in-process** — no network hop — using hybrid heuristic and entropy-based detection.
 
 ## Installation
 
@@ -26,8 +26,32 @@ console.log(redactedText);
 // Output will have the high entropy token redacted
 ```
 
+## Configuration
+
+`PiiShield.create(config)` accepts these overrides. Any field left unset keeps
+the core scanner default, so redaction matches the CLI for the same config.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `entropyThreshold` | number | Shannon entropy cut-off for candidate tokens. |
+| `confidenceScore` | number | Hybrid-validation confidence threshold. |
+| `salt` | string | HMAC salt for deterministic `[HIDDEN:xxxxxx]` tokens. Set it to correlate across processes. |
+| `minSecretLength` | number | Minimum candidate token length before entropy checks apply. |
+| `sensitiveKeys` | string[] | Key names whose values are always redacted (case-insensitive). Replaces the defaults. |
+| `disableBigramCheck` | boolean | Disable English bigram analysis (useful for non-English logs). |
+| `adaptiveThreshold` | boolean | Enable the **experimental** statistical adaptive-threshold mode. |
+| `failPolicy` | `"open"` \| `"closed"` | On an internal error, `open` returns the input unchanged; `closed` returns a drop marker. Handled in this wrapper. |
+
+### Unsupported config fields
+
+These core options are **not configurable via the SDK yet** — they require
+compiled state built only in the CLI/env path. Use the CLI or Kubernetes
+deployment if you need them: `sensitiveKeyPatterns`, `customRegexes`,
+`safeRegexes` (env vars `PII_SENSITIVE_KEY_PATTERNS`, `PII_CUSTOM_REGEX_LIST`,
+`PII_SAFE_REGEX_LIST`).
+
 ## Features
 
-- **Blazing Fast**: Runs a highly optimized Go WASM binary in NodeJS natively.
-- **Zero-Allocation**: Hot-paths have been optimized to prevent garbage collection overhead during large log streaming.
-- **Hybrid Scoring**: Combines static whitelists, regex heuristics, and Shannon entropy for zero false-positives on things like UUIDs and IPv6 addresses.
+- **In-process**: runs the Go WASM binary inside Node.js — no network hop by construction.
+- **Low-allocation hot path**: the scan loop is optimized to reduce garbage-collection overhead during large log streaming.
+- **Hybrid scoring**: combines static whitelists, regex heuristics, and Shannon entropy, which helps avoid false positives on structured values like UUIDs and IPv6 addresses.

--- a/sdks/node/index.d.ts
+++ b/sdks/node/index.d.ts
@@ -3,6 +3,14 @@ export interface PiiShieldConfig {
     salt?: string;
     confidenceScore?: number;
     failPolicy?: "open" | "closed";
+    /** Minimum candidate token length before entropy checks apply. */
+    minSecretLength?: number;
+    /** Key names whose values are always redacted (case-insensitive). Replaces the defaults. */
+    sensitiveKeys?: string[];
+    /** Disable English bigram analysis (useful for non-English logs). */
+    disableBigramCheck?: boolean;
+    /** Enable experimental statistical adaptive-threshold mode. */
+    adaptiveThreshold?: boolean;
 }
 
 export class PiiShield {

--- a/sdks/node/index.js
+++ b/sdks/node/index.js
@@ -44,7 +44,11 @@ class PiiShield {
         if (config.entropyThreshold) cfgObj.entropy_threshold = config.entropyThreshold;
         if (config.salt) cfgObj.salt = config.salt;
         if (config.confidenceScore) cfgObj.confidence_score = config.confidenceScore;
-        
+        if (config.minSecretLength) cfgObj.min_secret_length = config.minSecretLength;
+        if (config.sensitiveKeys) cfgObj.sensitive_keys = config.sensitiveKeys;
+        if (config.disableBigramCheck !== undefined) cfgObj.disable_bigram_check = config.disableBigramCheck;
+        if (config.adaptiveThreshold !== undefined) cfgObj.adaptive_threshold = config.adaptiveThreshold;
+
         const cfgJson = JSON.stringify(cfgObj);
         const cfgBytes = new TextEncoder().encode(cfgJson);
         const cfgPtr = shield.allocate(cfgBytes.length);

--- a/sdks/node/test.js
+++ b/sdks/node/test.js
@@ -1,4 +1,40 @@
 const { PiiShield } = require('./index');
+const fs = require('fs');
+const path = require('path');
+
+// Cross-entrypoint parity: load the shared golden (generated from the Go
+// scanner) and assert the Node SDK produces byte-identical output. See
+// sdks/parity/cases.json and sdks/parity/parity_test.go (issue #48).
+const SNAKE_TO_CAMEL = {
+    entropy_threshold: 'entropyThreshold',
+    salt: 'salt',
+    confidence_score: 'confidenceScore',
+    min_secret_length: 'minSecretLength',
+    sensitive_keys: 'sensitiveKeys',
+    disable_bigram_check: 'disableBigramCheck',
+    adaptive_threshold: 'adaptiveThreshold',
+};
+
+async function runParity() {
+    const casesPath = path.join(__dirname, '..', 'parity', 'cases.json');
+    const cases = JSON.parse(fs.readFileSync(casesPath, 'utf8'));
+    let ok = true;
+    for (const tc of cases) {
+        const cfg = {};
+        for (const [k, v] of Object.entries(tc.config)) {
+            cfg[SNAKE_TO_CAMEL[k] || k] = v;
+        }
+        const shield = await PiiShield.create(cfg, "../../pii-shield-wasi.wasm");
+        const got = shield.redact(tc.input);
+        if (got !== tc.expected) {
+            console.error(`PARITY FAIL [${tc.name}]\n  input:    ${JSON.stringify(tc.input)}\n  expected: ${JSON.stringify(tc.expected)}\n  got:      ${JSON.stringify(got)}`);
+            ok = false;
+        } else {
+            console.log(`parity ok: ${tc.name}`);
+        }
+    }
+    return ok;
+}
 
 async function main() {
     try {
@@ -27,7 +63,12 @@ async function main() {
             }
         }
         
-        // Let's assert memory bounds and GC? No, just the correct output is fine for now
+        // Cross-entrypoint parity against the shared golden.
+        const parityOk = await runParity();
+        if (!parityOk) {
+            passed = false;
+        }
+
         if (passed) {
             console.log("SUCCESS");
         } else {

--- a/sdks/parity/cases.json
+++ b/sdks/parity/cases.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "baseline_default_salt_sensitive_key",
+    "config": {},
+    "input": "user login password=SuperSecretValue123 ok",
+    "expected": "user login password=[HIDDEN:8836e2] ok"
+  },
+  {
+    "name": "explicit_salt_high_entropy_token",
+    "config": {
+      "salt": "parity-fixed-salt-01234567"
+    },
+    "input": "ref A1b2C3d4E5f6G7h8x9K0mN random tail",
+    "expected": "ref [HIDDEN:2c81ea] random tail"
+  },
+  {
+    "name": "sensitive_keys_override",
+    "config": {
+      "sensitive_keys": [
+        "ssn"
+      ]
+    },
+    "input": "ssn=hello password=world",
+    "expected": "ssn=[HIDDEN:b014e4] password=world"
+  },
+  {
+    "name": "min_secret_length_raised",
+    "config": {
+      "min_secret_length": 64
+    },
+    "input": "ref A1b2C3d4E5f6G7h8x9K0mN random tail",
+    "expected": "ref A1b2C3d4E5f6G7h8x9K0mN random tail"
+  }
+]

--- a/sdks/parity/parity_test.go
+++ b/sdks/parity/parity_test.go
@@ -1,0 +1,88 @@
+// Package parity holds the cross-entrypoint redaction parity golden
+// (cases.json) and the Go/CLI-side assertion. The Node and Python SDK tests
+// load the SAME cases.json and assert byte-identical output, so every
+// entrypoint (Go API, CLI, Node, Python) is proven to redact identically for a
+// given input and config. See sdks/*/test.* and issue #48.
+package parity
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pii-shield/pii-shield/pkg/scanner"
+)
+
+type parityCase struct {
+	Name     string                 `json:"name"`
+	Config   map[string]interface{} `json:"config"`
+	Input    string                 `json:"input"`
+	Expected string                 `json:"expected"`
+}
+
+// applyConfig mirrors the config mapping in cmd/wasm-ffi/main.go init_config,
+// including the fixed default salt the WASM kernel seeds. Keep the two in sync;
+// any drift makes the Node/Python SDK tests fail against this golden.
+func applyConfig(c map[string]interface{}) scanner.Config {
+	cfg := scanner.DefaultConfig()
+	cfg.Salt = []byte("pii-shield-default-salt-12345678")
+	if v, ok := c["salt"].(string); ok && v != "" {
+		cfg.Salt = []byte(v)
+	}
+	if v, ok := c["entropy_threshold"].(float64); ok && v > 0 {
+		cfg.EntropyThreshold = v
+	}
+	if v, ok := c["confidence_score"].(float64); ok && v > 0 {
+		cfg.ConfidenceThreshold = v
+	}
+	if v, ok := c["min_secret_length"].(float64); ok && v > 0 {
+		cfg.MinSecretLength = int(v)
+	}
+	if v, ok := c["sensitive_keys"].([]interface{}); ok && len(v) > 0 {
+		keys := make([]string, len(v))
+		for i, k := range v {
+			keys[i] = strings.ToLower(strings.TrimSpace(k.(string)))
+		}
+		cfg.SensitiveKeys = keys
+	}
+	if v, ok := c["disable_bigram_check"].(bool); ok {
+		cfg.DisableBigramCheck = v
+	}
+	if v, ok := c["adaptive_threshold"].(bool); ok {
+		cfg.AdaptiveThreshold = v
+	}
+	return cfg
+}
+
+func loadCases(t *testing.T) []parityCase {
+	t.Helper()
+	raw, err := os.ReadFile("cases.json")
+	if err != nil {
+		t.Fatalf("read cases.json: %v", err)
+	}
+	var cases []parityCase
+	if err := json.Unmarshal(raw, &cases); err != nil {
+		t.Fatalf("parse cases.json: %v", err)
+	}
+	if len(cases) == 0 {
+		t.Fatal("cases.json is empty")
+	}
+	return cases
+}
+
+// TestGoParity asserts the Go API (scanner.ScanAndRedact) reproduces the golden
+// for every case. The Node and Python SDKs assert the same golden via WASM.
+func TestGoParity(t *testing.T) {
+	for _, tc := range loadCases(t) {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			scanner.UpdateConfig(applyConfig(tc.Config))
+			got := scanner.ScanAndRedact(tc.Input)
+			if got != tc.Expected {
+				t.Fatalf("parity mismatch\n input:    %q\n config:   %v\n expected: %q\n got:      %q",
+					tc.Input, tc.Config, tc.Expected, got)
+			}
+		})
+	}
+}

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,6 +1,6 @@
 # pii-shield-wasi
 
-High-performance PII redaction scanner powered by a core Go engine compiled to WebAssembly (WASI). It provides lightning-fast text analysis with hybrid heuristic and entropy-based validation.
+PII redaction scanner powered by the core Go engine compiled to WebAssembly (WASI). It runs **in-process** — no network hop — using hybrid heuristic and entropy-based detection.
 
 ## Installation
 
@@ -26,8 +26,32 @@ print(redacted_text)
 # Output might redact the high entropy secret based on context
 ```
 
+## Configuration
+
+`PiiShieldConfig` accepts these overrides. Any field left unset keeps the core
+scanner default, so redaction matches the CLI for the same config.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `entropy_threshold` | float | Shannon entropy cut-off for candidate tokens. |
+| `confidence_score` | float | Hybrid-validation confidence threshold. |
+| `salt` | str | HMAC salt for deterministic `[HIDDEN:xxxxxx]` tokens. Set it to correlate across processes. |
+| `min_secret_length` | int | Minimum candidate token length before entropy checks apply. |
+| `sensitive_keys` | list[str] | Key names whose values are always redacted (case-insensitive). Replaces the defaults. |
+| `disable_bigram_check` | bool | Disable English bigram analysis (useful for non-English logs). |
+| `adaptive_threshold` | bool | Enable the **experimental** statistical adaptive-threshold mode. |
+| `fail_policy` | `"open"` \| `"closed"` | On an internal error, `open` returns the input unchanged; `closed` returns a drop marker. Handled in this wrapper. |
+
+### Unsupported config fields
+
+These core options are **not configurable via the SDK yet** — they require
+compiled state built only in the CLI/env path. Use the CLI or Kubernetes
+deployment if you need them: `sensitive_key_patterns`, `custom_regexes`,
+`safe_regexes` (env vars `PII_SENSITIVE_KEY_PATTERNS`, `PII_CUSTOM_REGEX_LIST`,
+`PII_SAFE_REGEX_LIST`).
+
 ## Features
 
-- **Blazing Fast**: Runs a highly optimized Go WASM binary in a native V8/Wasmtime environment.
-- **Zero-Allocation**: Hot-paths have been optimized to prevent garbage collection overhead during large log streaming.
-- **Hybrid Scoring**: Combines static whitelists, regex heuristics, and Shannon entropy for zero false-positives on things like UUIDs and IPv6 addresses.
+- **In-process**: runs the Go WASM binary inside Python via Wasmtime — no network hop by construction.
+- **Low-allocation hot path**: the scan loop is optimized to reduce garbage-collection overhead during large log streaming.
+- **Hybrid scoring**: combines static whitelists, regex heuristics, and Shannon entropy, which helps avoid false positives on structured values like UUIDs and IPv6 addresses.

--- a/sdks/python/pii_shield/scanner.py
+++ b/sdks/python/pii_shield/scanner.py
@@ -1,7 +1,7 @@
 import os
 import json
 from dataclasses import dataclass, asdict
-from typing import Optional
+from typing import List, Optional
 from wasmtime import Engine, Linker, Store, Config, Module, WasiConfig
 
 @dataclass
@@ -10,6 +10,14 @@ class PiiShieldConfig:
     salt: Optional[str] = None
     confidence_score: Optional[float] = None
     fail_policy: str = "open"
+    # Minimum candidate token length before entropy checks apply.
+    min_secret_length: Optional[int] = None
+    # Key names whose values are always redacted (case-insensitive). Replaces the defaults.
+    sensitive_keys: Optional[List[str]] = None
+    # Disable English bigram analysis (useful for non-English logs).
+    disable_bigram_check: Optional[bool] = None
+    # Enable experimental statistical adaptive-threshold mode.
+    adaptive_threshold: Optional[bool] = None
 
 class PiiShield:
     def __init__(self, config: PiiShieldConfig = None, wasm_path: str = None):
@@ -57,7 +65,15 @@ class PiiShield:
             cfg_dict["salt"] = self.config.salt
         if self.config.confidence_score is not None:
             cfg_dict["confidence_score"] = self.config.confidence_score
-            
+        if self.config.min_secret_length is not None:
+            cfg_dict["min_secret_length"] = self.config.min_secret_length
+        if self.config.sensitive_keys is not None:
+            cfg_dict["sensitive_keys"] = self.config.sensitive_keys
+        if self.config.disable_bigram_check is not None:
+            cfg_dict["disable_bigram_check"] = self.config.disable_bigram_check
+        if self.config.adaptive_threshold is not None:
+            cfg_dict["adaptive_threshold"] = self.config.adaptive_threshold
+
         cfg_json = json.dumps(cfg_dict).encode("utf-8")
         if len(cfg_json) > 0:
             cfg_ptr = self.allocate(self.store, len(cfg_json))

--- a/sdks/python/test.py
+++ b/sdks/python/test.py
@@ -1,5 +1,28 @@
 from pii_shield import PiiShield, PiiShieldConfig
+import json
+import os
 import sys
+
+def run_parity():
+    """Cross-entrypoint parity: assert the Python SDK reproduces the shared
+    golden generated from the Go scanner. See sdks/parity/cases.json and
+    sdks/parity/parity_test.go (issue #48). The PiiShieldConfig dataclass fields
+    are snake_case and match the golden's config keys directly."""
+    cases_path = os.path.join(os.path.dirname(__file__), "..", "parity", "cases.json")
+    with open(cases_path, "r", encoding="utf-8") as fh:
+        cases = json.load(fh)
+
+    ok = True
+    for tc in cases:
+        cfg = PiiShieldConfig(**tc["config"])
+        shield = PiiShield(config=cfg, wasm_path="../../pii-shield-wasi.wasm")
+        got = shield.redact(tc["input"])
+        if got != tc["expected"]:
+            print(f"PARITY FAIL [{tc['name']}]\n  input:    {tc['input']!r}\n  expected: {tc['expected']!r}\n  got:      {got!r}")
+            ok = False
+        else:
+            print(f"parity ok: {tc['name']}")
+    return ok
 
 def main():
     try:
@@ -21,6 +44,9 @@ def main():
             print(f"Redacted: {redacted}\n---")
             if "FATAL_ERROR" in redacted:
                 passed = False
+
+        if not run_parity():
+            passed = False
 
         if passed:
             print("SUCCESS")


### PR DESCRIPTION
Part 1 of #48. Makes the SDKs honor more of the scanner config and proves all
entrypoints redact identically. The core "defaults lost" bug was already fixed
in #85; this extends the config surface and adds parity coverage.

## Changes
- **WASM bridge** (`cmd/wasm-ffi`): forward `min_secret_length`, `sensitive_keys`
  (normalized to lower/trim like `loadConfig`), `disable_bigram_check`,
  `adaptive_threshold`. These are read directly from `currentConfig` at scan
  time, so no compiled/derived state is needed.
- **Node & Python SDKs**: expose the new options (`minSecretLength`,
  `sensitiveKeys`, `disableBigramCheck`, `adaptiveThreshold` / snake_case);
  update `index.d.ts` and the `PiiShieldConfig` dataclass.
- **Parity harness** (`sdks/parity/`): a shared `cases.json` golden generated
  from the Go scanner; `parity_test.go` asserts the Go API reproduces it, and
  the Node/Python `test.*` load the SAME golden and assert byte-identical output.
- **Docs**: SDK READMEs document supported options and explicitly list the
  **unsupported** fields (`sensitiveKeyPatterns`, `customRegexes`, `safeRegexes`
  — require compiled state, CLI/env only for now). Also downgraded pre-doctrine
  marketing claims ("lightning-fast", "zero-allocation", "zero false-positives")
  to mechanism language.
- `.gitignore`: ignore the build-artifact `pii-shield-wasi.wasm` and Python `__pycache__`.

## Verification (all on Linux, matching CI)
- WASM rebuilt in `golang:1.26`.
- `go test -race ./...` — pass; coverage scanner 85.6% / cleaner 92.2% / metrics 100% (≥70% gate).
- Node SDK (`node:20-slim`) and Python SDK (`python:3.11-slim`) — parity 4/4, byte-identical to the Go golden.
- Parity cases are differential: `sensitive_keys` override redacts `ssn` but leaves `password`; `min_secret_length: 64` leaves a token that defaults redact.

## Not in this PR (Part 2)
Full parity for `sensitiveKeyPatterns` / custom & safe regex lists needs a
`loadConfig` refactor to extract a shared compile step callable from
`init_config`. Tracked as the follow-up per the split.