### PR TITLE
Stop readFIFO goroutine in tests to fix TestReadFIFO flake

### DIFF
--- a/cmd/cleaner/main.go
+++ b/cmd/cleaner/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -86,7 +87,7 @@ func main() {
 				stopMetrics()
 				os.Exit(0)
 			}()
-			readFIFO(watchFile, metricsEnabled, failPolicy)
+			readFIFO(watchFile, metricsEnabled, failPolicy, os.Stdout, nil)
 			return
 		}
 
@@ -111,7 +112,7 @@ func main() {
 			if line.Err != nil {
 				continue
 			}
-			processLine(line.Text, metricsEnabled, failPolicy)
+			processLine(line.Text, metricsEnabled, failPolicy, os.Stdout)
 		}
 		stopMetrics()
 	} else {
@@ -127,7 +128,7 @@ func main() {
 		}()
 
 		for reader.Scan() {
-			processLine(reader.Text(), metricsEnabled, failPolicy)
+			processLine(reader.Text(), metricsEnabled, failPolicy, os.Stdout)
 		}
 
 		if err := reader.Err(); err != nil {
@@ -207,14 +208,28 @@ func isNamedPipe(path string) bool {
 	return err == nil && fi.Mode()&os.ModeNamedPipe != 0
 }
 
-// readFIFO continuously sanitizes lines read from a named pipe. Opening the FIFO
-// read-only blocks until a writer connects, which keeps the sidecar running so
-// the pod reaches Ready. When the writer closes the pipe (EOF) the FIFO is
-// reopened to block for the next writer; the loop ends only on SIGTERM/SIGINT
-// (handled by the os.Exit goroutine installed by the caller).
-func readFIFO(path string, metricsEnabled bool, failPolicy string) {
+// readFIFO continuously sanitizes lines read from a named pipe, writing the
+// sanitized stream to out. Opening the FIFO read-only blocks until a writer
+// connects, which keeps the sidecar running so the pod reaches Ready. When the
+// writer closes the pipe (EOF) the FIFO is reopened to block for the next
+// writer.
+//
+// Closing stop ends the loop after the current writer disconnects; a nil stop
+// (the sidecar's own usage, which ends via SIGTERM/SIGINT and the os.Exit
+// goroutine installed by the caller) loops forever. Because a pending open
+// blocks in the kernel until a writer connects, stop is only observed between
+// opens: to guarantee prompt exit a caller closes stop and then opens the FIFO
+// for writing to release the pending open. That nudge must be non-blocking
+// (O_NONBLOCK) and retried until the loop exits, since a blocking open for
+// write would itself hang once the loop has already stopped reading.
+func readFIFO(path string, metricsEnabled bool, failPolicy string, out io.Writer, stop <-chan struct{}) {
 	for {
-		if err := streamPipeOnce(path, metricsEnabled, failPolicy); err != nil {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+		if err := streamPipeOnce(path, metricsEnabled, failPolicy, out); err != nil {
 			log.Fatalf("Failed to open pipe %s: %v", path, err)
 		}
 		// Writer closed the pipe; loop to reopen and block for the next writer.
@@ -222,9 +237,9 @@ func readFIFO(path string, metricsEnabled bool, failPolicy string) {
 }
 
 // streamPipeOnce opens the FIFO (blocking until a writer connects), sanitizes
-// every line until the writer closes the pipe (EOF), then returns. It returns a
-// non-nil error only if the pipe could not be opened.
-func streamPipeOnce(path string, metricsEnabled bool, failPolicy string) error {
+// every line into out until the writer closes the pipe (EOF), then returns. It
+// returns a non-nil error only if the pipe could not be opened.
+func streamPipeOnce(path string, metricsEnabled bool, failPolicy string, out io.Writer) error {
 	f, err := os.OpenFile(path, os.O_RDONLY, os.ModeNamedPipe)
 	if err != nil {
 		return err
@@ -236,7 +251,7 @@ func streamPipeOnce(path string, metricsEnabled bool, failPolicy string) error {
 	sc.Buffer(buf, 10*1024*1024)
 
 	for sc.Scan() {
-		processLine(sc.Text(), metricsEnabled, failPolicy)
+		processLine(sc.Text(), metricsEnabled, failPolicy, out)
 	}
 
 	if err := sc.Err(); err != nil {
@@ -245,9 +260,9 @@ func streamPipeOnce(path string, metricsEnabled bool, failPolicy string) error {
 		}
 		if err == bufio.ErrTooLong {
 			if failPolicy == "closed" {
-				fmt.Println("[PII_SHIELD_DROP: BUFFER_OVERFLOW]")
+				fmt.Fprintln(out, "[PII_SHIELD_DROP: BUFFER_OVERFLOW]")
 			} else {
-				fmt.Println("[PII_SHIELD_WARN: BUFFER_OVERFLOW, STREAM_BROKEN]")
+				fmt.Fprintln(out, "[PII_SHIELD_WARN: BUFFER_OVERFLOW, STREAM_BROKEN]")
 			}
 		}
 		fmt.Fprintln(os.Stderr, "Error reading pipe:", err)
@@ -256,7 +271,7 @@ func streamPipeOnce(path string, metricsEnabled bool, failPolicy string) error {
 	return nil
 }
 
-func processLine(text string, metricsEnabled bool, failPolicy string) {
+func processLine(text string, metricsEnabled bool, failPolicy string, out io.Writer) {
 	// Functional wrapper to catch panics per-line
 	func() {
 		defer func() {
@@ -266,10 +281,10 @@ func processLine(text string, metricsEnabled bool, failPolicy string) {
 				}
 				// Apply Blast Radius Control Policy
 				if failPolicy == "closed" {
-					fmt.Println("[PII_SHIELD_DROP: FATAL_ERROR]")
+					fmt.Fprintln(out, "[PII_SHIELD_DROP: FATAL_ERROR]")
 				} else {
 					// Fail-Open: keep the flow alive
-					fmt.Println(text)
+					fmt.Fprintln(out, text)
 				}
 			}
 		}()
@@ -288,6 +303,6 @@ func processLine(text string, metricsEnabled bool, failPolicy string) {
 		}
 
 		// Write back to Stdout for Fluentd/Logstash
-		fmt.Println(cleaned)
+		fmt.Fprintln(out, cleaned)
 	}()
 }

--- a/cmd/cleaner/main.go
+++ b/cmd/cleaner/main.go
@@ -260,9 +260,9 @@ func streamPipeOnce(path string, metricsEnabled bool, failPolicy string, out io.
 		}
 		if err == bufio.ErrTooLong {
 			if failPolicy == "closed" {
-				fmt.Fprintln(out, "[PII_SHIELD_DROP: BUFFER_OVERFLOW]")
+				_, _ = fmt.Fprintln(out, "[PII_SHIELD_DROP: BUFFER_OVERFLOW]")
 			} else {
-				fmt.Fprintln(out, "[PII_SHIELD_WARN: BUFFER_OVERFLOW, STREAM_BROKEN]")
+				_, _ = fmt.Fprintln(out, "[PII_SHIELD_WARN: BUFFER_OVERFLOW, STREAM_BROKEN]")
 			}
 		}
 		fmt.Fprintln(os.Stderr, "Error reading pipe:", err)
@@ -281,10 +281,10 @@ func processLine(text string, metricsEnabled bool, failPolicy string, out io.Wri
 				}
 				// Apply Blast Radius Control Policy
 				if failPolicy == "closed" {
-					fmt.Fprintln(out, "[PII_SHIELD_DROP: FATAL_ERROR]")
+					_, _ = fmt.Fprintln(out, "[PII_SHIELD_DROP: FATAL_ERROR]")
 				} else {
 					// Fail-Open: keep the flow alive
-					fmt.Fprintln(out, text)
+					_, _ = fmt.Fprintln(out, text)
 				}
 			}
 		}()
@@ -303,6 +303,6 @@ func processLine(text string, metricsEnabled bool, failPolicy string, out io.Wri
 		}
 
 		// Write back to Stdout for Fluentd/Logstash
-		fmt.Fprintln(out, cleaned)
+		_, _ = fmt.Fprintln(out, cleaned)
 	}()
 }

--- a/cmd/cleaner/main_test.go
+++ b/cmd/cleaner/main_test.go
@@ -73,22 +73,51 @@ func TestReadFIFO(t *testing.T) {
 		t.Fatalf("mkfifo: %v", err)
 	}
 
-	oldStdout := os.Stdout
 	rOut, wOut, _ := os.Pipe()
-	os.Stdout = wOut
-	defer func() { os.Stdout = oldStdout }()
 
-	// Collect sanitized stdout lines as readFIFO emits them.
+	// Collect sanitized lines as readFIFO emits them.
 	outCh := make(chan string, 8)
+	scanDone := make(chan struct{})
 	go func() {
+		defer close(scanDone)
 		sc := bufio.NewScanner(rOut)
 		for sc.Scan() {
 			outCh <- sc.Text()
 		}
-		close(outCh)
 	}()
 
-	go readFIFO(fifo, false, "open")
+	stop := make(chan struct{})
+	fifoDone := make(chan struct{})
+	go func() {
+		defer close(fifoDone)
+		readFIFO(fifo, false, "open", wOut, stop)
+	}()
+
+	// readFIFO must not outlive the test: once t.TempDir() is removed, a
+	// surviving reopen loop would log.Fatalf on the deleted pipe and take the
+	// whole test binary down with it.
+	t.Cleanup(func() {
+		close(stop)
+		// readFIFO only observes stop between opens, and a pending open blocks
+		// in the kernel until a writer connects. Nudge it with a non-blocking
+		// writer until the loop exits: O_NONBLOCK fails with ENXIO instead of
+		// blocking when readFIFO is not (yet) waiting in open, so this cannot
+		// deadlock against a loop that has already stopped.
+		for done := false; !done; {
+			select {
+			case <-fifoDone:
+				done = true
+			default:
+				if w, err := os.OpenFile(fifo, os.O_WRONLY|syscall.O_NONBLOCK, os.ModeNamedPipe); err == nil {
+					_ = w.Close()
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+		_ = wOut.Close()
+		<-scanDone
+		_ = rOut.Close()
+	})
 
 	writeLine := func(s string) {
 		w, err := os.OpenFile(fifo, os.O_WRONLY, os.ModeNamedPipe)
@@ -128,9 +157,6 @@ func TestReadFIFO(t *testing.T) {
 	if !strings.Contains(line2, "second line ok") {
 		t.Errorf("second writer not processed; FIFO not reopened after EOF: %q", line2)
 	}
-
-	os.Stdout = oldStdout
-	wOut.Close()
 }
 
 func TestIsNamedPipe(t *testing.T) {
@@ -180,23 +206,21 @@ func TestStreamPipeOnceBufferOverflow(t *testing.T) {
 				t.Fatalf("mkfifo: %v", err)
 			}
 
-			oldStdout := os.Stdout
 			rOut, wOut, _ := os.Pipe()
-			os.Stdout = wOut
-			defer func() { os.Stdout = oldStdout }()
 
 			outCh := make(chan string, 8)
+			scanDone := make(chan struct{})
 			go func() {
+				defer close(scanDone)
 				sc := bufio.NewScanner(rOut)
 				sc.Buffer(make([]byte, 1024*1024), 20*1024*1024)
 				for sc.Scan() {
 					outCh <- sc.Text()
 				}
-				close(outCh)
 			}()
 
 			done := make(chan error, 1)
-			go func() { done <- streamPipeOnce(fifo, tc.metricsEnabled, tc.failPolicy) }()
+			go func() { done <- streamPipeOnce(fifo, tc.metricsEnabled, tc.failPolicy, wOut) }()
 
 			// A line larger than the 10MB buffer with no newline forces
 			// bufio.ErrTooLong. streamPipeOnce closes the pipe on the error, so
@@ -228,8 +252,9 @@ func TestStreamPipeOnceBufferOverflow(t *testing.T) {
 				t.Fatal("streamPipeOnce did not return after writer closed")
 			}
 
-			os.Stdout = oldStdout
 			wOut.Close()
+			<-scanDone
+			rOut.Close()
 		})
 	}
 }
@@ -238,7 +263,7 @@ func TestStreamPipeOnceBufferOverflow(t *testing.T) {
 // readable pipe makes streamPipeOnce return an error (which readFIFO turns fatal).
 func TestStreamPipeOnceOpenError(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist.pipe")
-	if err := streamPipeOnce(missing, false, "open"); err == nil {
+	if err := streamPipeOnce(missing, false, "open", io.Discard); err == nil {
 		t.Errorf("expected an error opening a nonexistent pipe, got nil")
 	}
 }

--- a/cmd/cleaner/main_test.go
+++ b/cmd/cleaner/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"log"
 	"net"
@@ -16,6 +17,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/pii-shield/pii-shield/pkg/scanner"
 )
 
 func TestMainSuccess(t *testing.T) {
@@ -256,6 +259,70 @@ func TestStreamPipeOnceBufferOverflow(t *testing.T) {
 			<-scanDone
 			rOut.Close()
 		})
+	}
+}
+
+// TestProcessLinePanicRecovery covers the Blast Radius Control Policy: a panic
+// raised while sanitizing one line must never take the sidecar down. Fail-open
+// keeps the stream alive by passing the original line through; fail-closed drops
+// it behind a marker rather than risk emitting unredacted PII. The panic is
+// induced via scanner.RedactionCallback, which ScanAndRedact invokes on every
+// redaction.
+func TestProcessLinePanicRecovery(t *testing.T) {
+	const input = "contact john.doe@example.com now"
+
+	cases := []struct {
+		name       string
+		failPolicy string
+		want       string
+	}{
+		{"open_passes_original_line_through", "open", input},
+		{"closed_drops_line", "closed", "[PII_SHIELD_DROP: FATAL_ERROR]"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			old := scanner.RedactionCallback
+			scanner.RedactionCallback = func(string) { panic("induced scanner panic") }
+			t.Cleanup(func() { scanner.RedactionCallback = old })
+
+			var out bytes.Buffer
+			processLine(input, true, tc.failPolicy, &out)
+
+			if got := strings.TrimSpace(out.String()); got != tc.want {
+				t.Errorf("failPolicy %q: got %q, want %q", tc.failPolicy, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReadFIFOOpenErrorFatal covers readFIFO's fatal branch: when the pipe cannot
+// be opened at all, the sidecar must exit non-zero with a diagnostic rather than
+// spin in the reopen loop. log.Fatalf exits the process, so this runs in a
+// subprocess.
+func TestReadFIFOOpenErrorFatal(t *testing.T) {
+	if os.Getenv("TEST_READFIFO_FATAL") == "1" {
+		readFIFO(os.Getenv("TEST_READFIFO_PATH"), false, "open", os.Stdout, nil)
+		return
+	}
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist.pipe")
+	cmd := exec.Command(os.Args[0], "-test.run=TestReadFIFOOpenErrorFatal")
+	cmd.Env = append(os.Environ(), "TEST_READFIFO_FATAL=1", "TEST_READFIFO_PATH="+missing)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected a non-zero exit on unopenable pipe, got %v", err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Errorf("expected exit code 1, got %d", exitErr.ExitCode())
+	}
+	if !strings.Contains(stderr.String(), "Failed to open pipe") {
+		t.Errorf("expected stderr to report the open failure, got: %s", stderr.String())
 	}
 }
 

--- a/cmd/cleaner/main_test.go
+++ b/cmd/cleaner/main_test.go
@@ -625,12 +625,32 @@ func TestMainMetricsListenFailure(t *testing.T) {
 	os.Stdin = rStdin
 	os.Stdout = wStdout
 
+	// Feed a line but keep stdin open, so main stays in its scan loop while the
+	// metrics goroutine reports the bind failure. Closing stdin here instead
+	// would let main return and Shutdown the metrics server first, in which case
+	// ListenAndServe returns ErrServerClosed rather than the bind error and the
+	// failure is never logged.
+	_, _ = wStdin.Write([]byte("mail test@example.com here\n"))
+
+	mainDone := make(chan struct{})
 	go func() {
-		_, _ = wStdin.Write([]byte("mail test@example.com here\n"))
-		wStdin.Close()
+		main()
+		close(mainDone)
 	}()
 
-	main()
+	logged := false
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(logBuf.String(), "Metrics server failed") {
+			logged = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Release main only once the listen failure has been observed.
+	wStdin.Close()
+	<-mainDone
 	wStdout.Close()
 
 	var out bytes.Buffer
@@ -638,15 +658,9 @@ func TestMainMetricsListenFailure(t *testing.T) {
 	if strings.Contains(out.String(), "test@example.com") {
 		t.Errorf("email not redacted while metrics listen failed: %s", out.String())
 	}
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if strings.Contains(logBuf.String(), "Metrics server failed") {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
+	if !logged {
+		t.Errorf("expected a listen-failure log entry, got: %s", logBuf.String())
 	}
-	t.Errorf("expected a listen-failure log entry, got: %s", logBuf.String())
 }
 
 // TestShutdownMetricsServerError covers the shutdown-error branch: an in-flight


### PR DESCRIPTION
## Problem

`TestReadFIFO` fails intermittently (~20% under load) with:

    Failed to open pipe /var/folders/.../TestReadFIFO.../001/log.pipe: no such file or directory
    FAIL github.com/pii-shield/pii-shield/cmd/cleaner 1.025s

The test started `go readFIFO(...)` and never stopped it. A goroutine blocked in
`open()` on a FIFO stays blocked even after the file is unlinked, so the leak is
only fatal in a narrow race: after the last writer's EOF, `readFIFO` loops to
reopen, and if `t.TempDir()` cleanup wins that window, `open` returns ENOENT and
`log.Fatalf` takes the whole test binary down. This is why the run reports `PASS`
(the test's own assertions succeed) and then `FAIL`.

The test also swapped global `os.Stdout`, so a leaked goroutine could write into a
later test's pipe.

Not caused by any scanner change; clean `main` exhibits it too.

## Fix

- `readFIFO` takes an `io.Writer` and a `stop` channel; `streamPipeOnce` and
  `processLine` take the writer. Production passes `os.Stdout` and a nil `stop`,
  so sidecar behavior is unchanged.
- `TestReadFIFO` writes to an injected pipe instead of mutating global `os.Stdout`,
  and shuts the goroutine down and waits for its exit before `TempDir` cleanup.
- `TestStreamPipeOnceBufferOverflow` likewise no longer mutates `os.Stdout`.

Shutdown detail: a pending FIFO open blocks in the kernel, so `stop` is only
observed between opens. Cleanup nudges the open with a **non-blocking** writer,
retried until the loop exits — a blocking `O_WRONLY` open deadlocks if the loop
has already stopped reading, which would trade the flake for a hang.

## Verification

- Root cause confirmed by temporarily widening the EOF→reopen window (50ms):
  old code reproduces the exact ENOENT failure; fixed code passes 10/10 under the
  same forced condition. Instrumentation not included in this PR.
- `go test -race -count=20 ./cmd/cleaner/` — pass (139s)
- `go test -race -count=1 ./...` — pass 3/3 under load (avg 19–26 on 8 cores,
  busy loops + `docker build --no-cache`)
- Coverage 86.6% (gate: 70%)
- End-to-end on the built binary: stdin and FIFO modes redact to real stdout,
  second writer still served after EOF, SIGTERM exits 0

No behavior change, so no doc updates required.