### PR TITLE
Add checklist lead magnet and Compliance Packs waitlist links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ spec:
 
 The Operator will automatically inject the `pii-shield-agent` using the Native Sidecar pattern (K8s 1.28+) and securely mask all logs!
 
+---
+
+📋 **Free: 25-point Kubernetes Log PII Audit Checklist** — where PII leaks from pods, which log paths bypass your filters, and how to verify redaction actually works. [Get the checklist →](https://pii-shield.com/#checklist)
+
+📦 **Compliance Packs (GDPR/HIPAA/PCI) coming soon** — [get early access →](https://pii-shield.com/#waitlist)
+
 ## Verification
 This project is verified with a growing testing suite intended to raise confidence before production hardening:
 1. **Unit Tests**: Cover edge cases, multilingual support, and JSON integrity with >85% coverage.


### PR DESCRIPTION
Adds two lead-magnet lines right after Quick Start, per the funnel plan (STR-1.3b).

- **Checklist (primary):** links to https://pii-shield.com/#checklist — the live opt-in form for the free 25-point audit checklist.
- **Compliance Packs (secondary):** "coming soon" waitlist, links to https://pii-shield.com/#waitlist.

Both anchors are already live on the site. Docs-only change; "coming soon" is used as the planned-status label per the project's claim policy (no capability is asserted as shipping).