### PR TITLE
Add configurable webhook strict mode denying pods without a PiiPolicy (#45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,13 @@ jobs:
         helm lint charts/pii-shield-operator
         helm template charts/pii-shield >/dev/null
         helm template charts/pii-shield-operator >/dev/null
+        # Webhook policy rendering: overrides must reach the manifests.
+        helm template charts/pii-shield-operator \
+          --set webhook.failurePolicy=Fail --set webhook.strictMode=true \
+          | grep -q 'failurePolicy: Fail'
+        helm template charts/pii-shield-operator \
+          --set webhook.strictMode=true \
+          | grep -q 'STRICT_MODE'
 
     - name: Verify Helm Runtime
       run: scripts/verify-helm-runtime.sh

--- a/charts/pii-shield-operator/templates/deployment.yaml
+++ b/charts/pii-shield-operator/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
           value: "{{ .Values.sidecar.fsGroup }}"
         - name: LEGACY_SIDECAR_MODE
           value: "{{ .Values.sidecar.legacySidecarMode }}"
+        - name: STRICT_MODE
+          value: "{{ .Values.webhook.strictMode }}"
         {{- if .Values.sidecar.saltSecret.name }}
         - name: AGENT_SALT_SECRET_NAME
           value: "{{ .Values.sidecar.saltSecret.name }}"

--- a/charts/pii-shield-operator/values.yaml
+++ b/charts/pii-shield-operator/values.yaml
@@ -57,6 +57,11 @@ webhook:
   useCertManager: true
   # Admission failure behavior. Use Ignore for availability-first rollout, Fail for compliance-sensitive enforcement.
   failurePolicy: Ignore
+  # Strict mode: deny pods that request injection (pii-shield.io/inject: "true")
+  # but have no resolvable PiiPolicy, instead of letting them start unprotected.
+  # For real enforcement, pair strictMode: true with failurePolicy: Fail so the
+  # denial cannot be bypassed when the webhook is unavailable.
+  strictMode: false
 
 podDisruptionBudget:
   enabled: false

--- a/docs/operator-stabilization.md
+++ b/docs/operator-stabilization.md
@@ -56,6 +56,25 @@ Production recommendation:
 - Start with `Ignore` during controlled rollout.
 - Move to `Fail` only after webhook health alerts, runbooks, and emergency bypass procedures are tested.
 
+## Webhook Strict Mode
+
+`webhook.strictMode` controls what the webhook does when a pod requests injection
+(`pii-shield.io/inject: "true"`) but no matching `PiiPolicy` can be resolved.
+
+| Value | Behavior | Use case |
+| --- | --- | --- |
+| `false` (default) | The pod is admitted **without** a sidecar, and the admission response carries a warning that logs are not redacted. Preserves current compatibility. | Availability-first rollout and early adoption. |
+| `true` | The pod is **denied** until a `PiiPolicy` exists, so no unprotected workload starts. | Compliance-sensitive enforcement. |
+
+`failurePolicy` and `strictMode` are independent but complementary. `strictMode`
+only takes effect when the webhook actually runs; if the webhook is unavailable,
+`failurePolicy: Ignore` still lets pods through. For real enforcement, pair
+**`strictMode: true` with `failurePolicy: Fail`** so a pod cannot bypass the
+policy requirement either by missing policy or by an unavailable webhook.
+
+Skipped and denied injections are logged by the operator and surfaced as
+admission warnings/messages, so they are visible in `kubectl` output and events.
+
 ## CRD Upgrade Safety
 
 Before upgrading CRDs:

--- a/operator/internal/webhook/pod_mutator.go
+++ b/operator/internal/webhook/pod_mutator.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	piishieldv1alpha1 "github.com/pii-shield/pii-shield/operator/api/v1alpha1"
@@ -22,6 +23,24 @@ type PodMutator struct {
 	Client            client.Client
 	Decoder           admission.Decoder
 	LegacySidecarMode bool
+	// StrictMode denies pods that request injection but have no resolvable
+	// PiiPolicy. It is the default; the STRICT_MODE env var (set from the
+	// chart's webhook.strictMode value) overrides it at runtime.
+	StrictMode bool
+}
+
+// strictMode reports whether the webhook should deny pods that request
+// injection but have no resolvable PiiPolicy. The STRICT_MODE env var is
+// authoritative when set; otherwise the struct field (used by tests) applies.
+func (m *PodMutator) strictMode() bool {
+	switch strings.ToLower(os.Getenv("STRICT_MODE")) {
+	case "true":
+		return true
+	case "false":
+		return false
+	default:
+		return m.StrictMode
+	}
 }
 
 // +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.kb.io,sideEffects=None,admissionReviewVersions=v1
@@ -42,9 +61,23 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 		policyName = "default"
 	}
 
+	log := logf.FromContext(ctx)
 	policy := &piishieldv1alpha1.PiiPolicy{}
 	if err := m.Client.Get(ctx, client.ObjectKey{Name: policyName, Namespace: req.Namespace}, policy); err != nil {
-		return admission.Allowed("Policy not found, skipping injection")
+		if m.strictMode() {
+			log.Info("strict mode: denying pod that requests injection but has no PiiPolicy",
+				"pod", pod.Name, "namespace", req.Namespace, "policy", policyName)
+			return admission.Denied(fmt.Sprintf(
+				"PII-Shield strict mode: pod requires PiiPolicy %q in namespace %q, but it was not found",
+				policyName, req.Namespace))
+		}
+		log.Info("permissive mode: skipping injection for pod with no PiiPolicy",
+			"pod", pod.Name, "namespace", req.Namespace, "policy", policyName)
+		resp := admission.Allowed("Policy not found, skipping injection")
+		resp.Warnings = append(resp.Warnings, fmt.Sprintf(
+			"PII-Shield: no PiiPolicy %q found in namespace %q; sidecar NOT injected and logs are NOT redacted. Enable webhook strict mode to deny such pods.",
+			policyName, req.Namespace))
+		return resp
 	}
 
 	targetContainerName := pod.Annotations["pii-shield.io/target-container"]

--- a/operator/internal/webhook/pod_mutator_test.go
+++ b/operator/internal/webhook/pod_mutator_test.go
@@ -195,6 +195,86 @@ func TestHandlePipeModeReturnsExperimentalWarning(t *testing.T) {
 	assert.Contains(t, resp.Warnings[0], "/bin/sh -c")
 }
 
+// handleInjectPod builds an admission request for a pod that requests injection
+// but for which the given mutator's client has no matching PiiPolicy (unless one
+// is seeded). Used by the strict-mode tests below.
+func handleForMissingPolicy(t *testing.T, mutator *PodMutator) admission.Response {
+	t.Helper()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"pii-shield.io/inject": "true"},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+	}
+	raw, err := json.Marshal(pod)
+	assert.NoError(t, err)
+	return mutator.Handle(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Namespace: "test-ns",
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+	})
+}
+
+func newEmptyMutator(t *testing.T) *PodMutator {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, piishieldv1alpha1.AddToScheme(scheme))
+	return &PodMutator{
+		Client:  fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Decoder: admission.NewDecoder(scheme),
+	}
+}
+
+func TestHandleMissingPolicyPermissiveAllowsWithWarning(t *testing.T) {
+	m := newEmptyMutator(t) // StrictMode defaults to false
+	resp := handleForMissingPolicy(t, m)
+
+	assert.True(t, resp.Allowed, "permissive mode should allow the pod")
+	assert.Empty(t, resp.Patches, "no sidecar should be injected")
+	assert.Len(t, resp.Warnings, 1)
+	assert.Contains(t, resp.Warnings[0], "NOT injected")
+}
+
+func TestHandleMissingPolicyStrictDenies(t *testing.T) {
+	m := newEmptyMutator(t)
+	m.StrictMode = true
+	resp := handleForMissingPolicy(t, m)
+
+	assert.False(t, resp.Allowed, "strict mode should deny the pod")
+	assert.Contains(t, resp.Result.Message, "strict mode")
+	assert.Contains(t, resp.Result.Message, "not found")
+}
+
+func TestHandleStrictModeEnvOverridesField(t *testing.T) {
+	// STRICT_MODE env is authoritative even when the struct field is false.
+	t.Setenv("STRICT_MODE", "true")
+	m := newEmptyMutator(t) // field false
+	resp := handleForMissingPolicy(t, m)
+	assert.False(t, resp.Allowed, "STRICT_MODE=true env should force denial")
+}
+
+func TestHandleInvalidInjectionModeErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, piishieldv1alpha1.AddToScheme(scheme))
+	policy := &piishieldv1alpha1.PiiPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "test-ns"},
+		Spec:       piishieldv1alpha1.PiiPolicySpec{InjectionMode: "bogus"},
+	}
+	m := &PodMutator{
+		Client:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy).Build(),
+		Decoder: admission.NewDecoder(scheme),
+	}
+	resp := handleForMissingPolicy(t, m) // policy exists, but mode is invalid
+
+	assert.False(t, resp.Allowed, "an unknown injection mode should not be allowed")
+	assert.Contains(t, resp.Result.Message, "unknown injection mode")
+}
+
 func TestBuildSidecarPassesScannerEnv(t *testing.T) {
 	policy := &piishieldv1alpha1.PiiPolicy{
 		Spec: piishieldv1alpha1.PiiPolicySpec{


### PR DESCRIPTION
Closes #45. Adds an opt-in strict mode so pods that request injection but have no
resolvable PiiPolicy are denied instead of starting unprotected. Permissive
behavior stays the default.

## Changes
- **Operator**: `PodMutator.StrictMode`; when a pod is labeled for injection but no
  PiiPolicy resolves, strict mode returns `admission.Denied`, permissive mode
  returns `Allowed` with a warning that logs are NOT redacted. Controlled by the
  `STRICT_MODE` env (authoritative), with the struct field as the test default.
- **Skipped/denied injections are logged** and surfaced as admission warnings/messages.
- **Chart**: new `webhook.strictMode` value → `STRICT_MODE` env on the operator
  Deployment. `webhook.failurePolicy` was already templated.
- **Docs**: `docs/operator-stabilization.md` documents strict mode and the
  recommendation to pair `strictMode: true` with `failurePolicy: Fail`.
- **CI**: helm-lint step now asserts `failurePolicy` and `STRICT_MODE` render from overrides.

## Verification
- `go test -race ./operator/...` — pass, incl. 5 new webhook tests: missing policy
  (permissive→allow+warning, strict→deny), STRICT_MODE env override, invalid
  injection mode → errored.
- `make -C operator manifests generate` — no generated-file drift (no API/CRD change).
- `helm lint` + rendering assertions (default `Ignore`/off; `--set` → `Fail`/`STRICT_MODE=true`) — pass.
- `scripts/verify-helm-runtime.sh` — pass.

## Note
Operator envtest integration suite targets the controller package (not this
webhook change) and runs in CI; the webhook logic is covered by the unit tests above.