### PR TITLE
Add opt-in aggregated redaction stats summary to CLI logs (STR-2.2)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -40,6 +40,17 @@ Set `PII_REQUIRE_STRONG_SALT=true` in production if you want startup to fail ins
 
 See `docs/sidecar-failure-modes.md` for production failure-mode guidance.
 
+## Observability
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PII_METRICS_ENABLED` | Expose a Prometheus `/metrics` endpoint and a `/healthz` probe. | `false` |
+| `PII_METRICS_PORT` | Port for the metrics/health server (1–65535). | `9090` |
+| `PII_STATS_LOG_INTERVAL` | When set to a positive Go duration (e.g. `1h`, `30m`), log a periodic aggregated redaction summary — counts of high-entropy secrets, pattern matches, and card numbers, plus lines and bytes processed — and a final summary on shutdown. Empty or invalid disables it. Independent of `PII_METRICS_ENABLED`. | _(disabled)_ |
+
+The stats summary is a single log line per interval, e.g.
+`PII-Shield stats: 1,240 redactions (900 high-entropy secrets, 297 pattern matches, 43 card numbers) across 12,345 lines / 5.2 MB processed`.
+
 ## Value-Based Regex Redaction (Deterministic)
 
 | Variable | Description |

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY go.mod ./
 COPY . .
 
 # Build static binary
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o pii-shield cmd/cleaner/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o pii-shield ./cmd/cleaner
 
 # Stage 2: Run
 FROM scratch

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -8,7 +8,7 @@ RUN go mod download
 
 COPY . .
 # Build statically linked binary
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o pii-shield ./cmd/cleaner/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o pii-shield ./cmd/cleaner
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/cmd/cleaner/main.go
+++ b/cmd/cleaner/main.go
@@ -23,11 +23,31 @@ import (
 
 func main() {
 	metricsEnabled := os.Getenv("PII_METRICS_ENABLED") == "true"
+
+	// Optional periodic value-metrics summary in the logs (STR-2.2). Opt-in via
+	// PII_STATS_LOG_INTERVAL so default log output is unchanged.
+	statsInterval := parseStatsInterval(os.Getenv("PII_STATS_LOG_INTERVAL"))
+	if raw := os.Getenv("PII_STATS_LOG_INTERVAL"); raw != "" && statsInterval == 0 {
+		log.Printf("Invalid PII_STATS_LOG_INTERVAL %q, stats summary disabled", raw)
+	}
+	if statsInterval > 0 {
+		stats = newStatsCollector()
+	}
+
+	// A single callback fans out to metrics and/or the stats summary.
+	if metricsEnabled || stats != nil {
+		scanner.RedactionCallback = func(strategy string) {
+			if metricsEnabled {
+				metrics.IncrementRedaction(strategy)
+			}
+			if stats != nil {
+				stats.recordRedaction(strategy)
+			}
+		}
+	}
+
 	var metricsSrv *http.Server
 	if metricsEnabled {
-		// Wire metrics callback
-		scanner.RedactionCallback = metrics.IncrementRedaction
-
 		port, err := resolveMetricsPort(os.Getenv("PII_METRICS_PORT"))
 		if err != nil {
 			// The sidecar's job is sanitizing logs; a bad metrics port must not
@@ -45,6 +65,25 @@ func main() {
 		}
 	}
 	stopMetrics := func() { shutdownMetricsServer(metricsSrv, metricsShutdownGrace) }
+
+	// finalize runs on every shutdown path: emit a last stats summary (if enabled)
+	// and drain the metrics server.
+	finalize := func() {
+		if stats != nil {
+			log.Print(stats.summary())
+		}
+		stopMetrics()
+	}
+
+	if stats != nil {
+		go func() {
+			ticker := time.NewTicker(statsInterval)
+			defer ticker.Stop()
+			for range ticker.C {
+				log.Print(stats.summary())
+			}
+		}()
+	}
 
 	failPolicy := os.Getenv("PII_FAIL_POLICY")
 	if failPolicy == "" {
@@ -70,7 +109,7 @@ func main() {
 			}
 			select {
 			case <-sigChan:
-				stopMetrics()
+				finalize()
 				os.Exit(0)
 			case <-time.After(500 * time.Millisecond):
 			}
@@ -84,7 +123,7 @@ func main() {
 		if isNamedPipe(watchFile) {
 			go func() {
 				<-sigChan
-				stopMetrics()
+				finalize()
 				os.Exit(0)
 			}()
 			readFIFO(watchFile, metricsEnabled, failPolicy, os.Stdout, nil)
@@ -114,7 +153,7 @@ func main() {
 			}
 			processLine(line.Text, metricsEnabled, failPolicy, os.Stdout)
 		}
-		stopMetrics()
+		finalize()
 	} else {
 		// Legacy Stdin mode
 		reader := bufio.NewScanner(os.Stdin)
@@ -123,7 +162,7 @@ func main() {
 
 		go func() {
 			<-sigChan
-			stopMetrics()
+			finalize()
 			os.Exit(0)
 		}()
 
@@ -143,10 +182,10 @@ func main() {
 				}
 			}
 			fmt.Fprintln(os.Stderr, "Error reading standard input:", err)
-			stopMetrics()
+			finalize()
 			os.Exit(1)
 		}
-		stopMetrics()
+		finalize()
 	}
 }
 
@@ -293,6 +332,9 @@ func processLine(text string, metricsEnabled bool, failPolicy string, out io.Wri
 		if metricsEnabled {
 			start = time.Now()
 			metrics.ProcessedBytesTotal.Add(float64(len(text)))
+		}
+		if stats != nil {
+			stats.recordLine(len(text))
 		}
 
 		// Core logic

--- a/cmd/cleaner/stats.go
+++ b/cmd/cleaner/stats.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// stats, when non-nil, accumulates redaction counts for the periodic value-metrics
+// log summary (STR-2.2). It is enabled only when PII_STATS_LOG_INTERVAL is set to a
+// positive duration, so default log output is unchanged.
+var stats *statsCollector
+
+// statsCollector aggregates redaction counts by strategy plus processed volume.
+// All counters are atomic: recordRedaction runs on the scanner hot path (via
+// RedactionCallback) and recordLine runs once per processed line.
+type statsCollector struct {
+	entropy atomic.Uint64
+	regex   atomic.Uint64
+	luhn    atomic.Uint64
+	other   atomic.Uint64
+	lines   atomic.Uint64
+	bytes   atomic.Uint64
+}
+
+func newStatsCollector() *statsCollector { return &statsCollector{} }
+
+// recordRedaction maps a scanner strategy ("entropy", "regex", "luhn") to a
+// counter. Unknown strategies fall into "other" so new detectors are not lost.
+func (s *statsCollector) recordRedaction(strategy string) {
+	switch strategy {
+	case "entropy":
+		s.entropy.Add(1)
+	case "regex":
+		s.regex.Add(1)
+	case "luhn":
+		s.luhn.Add(1)
+	default:
+		s.other.Add(1)
+	}
+}
+
+func (s *statsCollector) recordLine(n int) {
+	s.lines.Add(1)
+	if n > 0 {
+		s.bytes.Add(uint64(n))
+	}
+}
+
+// summary renders a single human-readable log line with cumulative counts since
+// process start. Labels describe the actual detection strategy — we do not claim
+// semantic categories (e.g. "emails") the scanner does not track.
+func (s *statsCollector) summary() string {
+	entropy := s.entropy.Load()
+	regex := s.regex.Load()
+	luhn := s.luhn.Load()
+	other := s.other.Load()
+	total := entropy + regex + luhn + other
+
+	parts := []string{
+		fmt.Sprintf("%s high-entropy secrets", withThousands(entropy)),
+		fmt.Sprintf("%s pattern matches", withThousands(regex)),
+		fmt.Sprintf("%s card numbers", withThousands(luhn)),
+	}
+	if other > 0 {
+		parts = append(parts, fmt.Sprintf("%s other", withThousands(other)))
+	}
+
+	return fmt.Sprintf("PII-Shield stats: %s redactions (%s) across %s lines / %s processed",
+		withThousands(total), strings.Join(parts, ", "), withThousands(s.lines.Load()), humanBytes(s.bytes.Load()))
+}
+
+// parseStatsInterval returns the configured summary interval. An empty value
+// disables the summary; an invalid or non-positive value also disables it (the
+// caller logs the warning) rather than failing the log pipeline.
+func parseStatsInterval(raw string) time.Duration {
+	if strings.TrimSpace(raw) == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(raw))
+	if err != nil || d <= 0 {
+		return 0
+	}
+	return d
+}
+
+// withThousands formats n with comma separators (1240 -> "1,240").
+func withThousands(n uint64) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	var b strings.Builder
+	pre := len(s) % 3
+	if pre > 0 {
+		b.WriteString(s[:pre])
+		if len(s) > pre {
+			b.WriteByte(',')
+		}
+	}
+	for i := pre; i < len(s); i += 3 {
+		b.WriteString(s[i : i+3])
+		if i+3 < len(s) {
+			b.WriteByte(',')
+		}
+	}
+	return b.String()
+}
+
+// humanBytes renders a byte count as B/KB/MB/GB with one decimal place.
+func humanBytes(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := uint64(unit), 0
+	for m := n / unit; m >= unit; m /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/cleaner/stats_test.go
+++ b/cmd/cleaner/stats_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStatsCollectorSummary(t *testing.T) {
+	s := newStatsCollector()
+	// 900 entropy, 297 regex, 43 luhn, 1 unknown -> other.
+	for i := 0; i < 900; i++ {
+		s.recordRedaction("entropy")
+	}
+	for i := 0; i < 297; i++ {
+		s.recordRedaction("regex")
+	}
+	for i := 0; i < 43; i++ {
+		s.recordRedaction("luhn")
+	}
+	s.recordRedaction("future-detector")
+	for i := 0; i < 1500; i++ {
+		s.recordLine(1000)
+	}
+
+	got := s.summary()
+	for _, want := range []string{
+		"1,241 redactions", // 900+297+43+1
+		"900 high-entropy secrets",
+		"297 pattern matches",
+		"43 card numbers",
+		"1 other",
+		"1,500 lines",
+		"1.4 MB processed",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary missing %q\n got: %s", want, got)
+		}
+	}
+}
+
+func TestStatsCollectorOmitsOtherWhenZero(t *testing.T) {
+	s := newStatsCollector()
+	s.recordRedaction("entropy")
+	if strings.Contains(s.summary(), "other") {
+		t.Errorf("summary should omit 'other' when zero: %s", s.summary())
+	}
+}
+
+func TestParseStatsInterval(t *testing.T) {
+	cases := map[string]time.Duration{
+		"":      0,
+		"   ":   0,
+		"0":     0,
+		"-5m":   0,
+		"bogus": 0,
+		"30s":   30 * time.Second,
+		" 1h ":  time.Hour,
+		"1h30m": 90 * time.Minute,
+	}
+	for in, want := range cases {
+		if got := parseStatsInterval(in); got != want {
+			t.Errorf("parseStatsInterval(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestWithThousands(t *testing.T) {
+	cases := map[uint64]string{0: "0", 12: "12", 999: "999", 1000: "1,000", 12345: "12,345", 1000000: "1,000,000"}
+	for in, want := range cases {
+		if got := withThousands(in); got != want {
+			t.Errorf("withThousands(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	cases := map[uint64]string{512: "512 B", 1024: "1.0 KB", 1536: "1.5 KB", 5 * 1024 * 1024: "5.0 MB"}
+	for in, want := range cases {
+		if got := humanBytes(in); got != want {
+			t.Errorf("humanBytes(%d) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a periodic value-metrics log line so Security/Compliance teams get concrete
numbers (STR-2.2). Opt-in and off by default, so existing log output is unchanged.

## Behavior
Set `PII_STATS_LOG_INTERVAL` to a positive Go duration (e.g. `1h`) to log a
summary every interval plus a final summary on shutdown:

    PII-Shield stats: 1,240 redactions (900 high-entropy secrets, 297 pattern matches, 43 card numbers) across 12,345 lines / 5.2 MB processed

## Changes
- `cmd/cleaner/stats.go`: atomic `statsCollector` (per-strategy counts, lines, bytes),
  `parseStatsInterval`, human-readable formatting.
- `cmd/cleaner/main.go`: `RedactionCallback` now fans out to metrics and/or stats;
  ticker goroutine logs on interval; `finalize()` logs a final summary on every
  shutdown path.
- `CONFIGURATION.md`: new Observability section documenting `PII_STATS_LOG_INTERVAL`
  (and the previously-undocumented `PII_METRICS_*`).

## Honesty note
Labels reflect the scanner's actual strategies (`entropy`/`regex`/`luhn`) — I did
**not** invent an "emails redacted" counter the scanner doesn't track. The strategy
doc's "emails" example was illustrative; the real detectors are high-entropy
secrets, pattern matches, and Luhn card numbers.

## Verification
- `go test -race ./...` — pass; cmd/cleaner 92.9%, total 88.4% (gate ≥70%).
- New unit tests: summary content, `other` omission, interval parsing (incl. invalid/negative), number/byte formatting.
- Functional: piped input with `PII_STATS_LOG_INTERVAL=1h` emits the summary on exit — verified.
- Not a detection-behavior change (redaction output byte-identical; stats are opt-in log lines), so smoke not required.