### PR TITLE
Fix documentation drift: stale versions, config gaps, readiness vocabulary

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -19,8 +19,9 @@ Set `PII_REQUIRE_STRONG_SALT=true` in production if you want startup to fail ins
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `PII_ENTROPY_THRESHOLD` | Shannon entropy threshold (3.0 - 8.0). Higher = fewer false positives, but might miss simple passwords. | `3.6` |
+| `PII_CONFIDENCE_THRESHOLD` | Multiplier applied to the effective entropy threshold. Values above `1.2` also restrict credit-card (Luhn) matches to lines containing card context words (`card`, `cc`, `pan`, `visa`). | `1.0` |
 | `PII_MIN_SECRET_LENGTH` | Minimum length of a string to be considered a candidate token. | `6` |
-| `PII_SENSITIVE_KEYS` | Comma-separated list of keys to *always* redact values for (case-insensitive). | `password,secret,token,key,api_key,aws_access_key_id,aws_secret_access_key,gcp_credentials,slack_token...` |
+| `PII_SENSITIVE_KEYS` | Comma-separated list of keys to *always* redact values for (case-insensitive, substring match). **Replaces** the default list instead of extending it. | `pass,secret,token,key,cvv,cvc,auth,sign,password,passwd,api_key,apikey,access_token,client_secret,aws_access_key_id,aws_secret_access_key,gcp_credentials,slack_token` |
 | `PII_SENSITIVE_KEY_PATTERNS` | Comma-separated list of regex patterns for key detection. | (empty) |
 
 ## Advanced Features
@@ -56,6 +57,9 @@ The stats summary is a single log line per interval, e.g.
 | Variable | Description |
 |----------|-------------|
 | `PII_CUSTOM_REGEX_LIST` | JSON array of regex objects to enforce redaction regardless of entropy. Supports named placeholders. |
+
+> [!WARNING]
+> **Fatal on invalid input:** malformed JSON or an invalid regex pattern in `PII_CUSTOM_REGEX_LIST` or `PII_SAFE_REGEX_LIST` terminates the process at startup, before any log line is processed. In a sidecar this shows up as a crash loop. Validate the JSON and every pattern before rollout.
 
 ### Example
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Acceptable contributions should:
 
 ## Prerequisites
 You will need the following tools:
-- **Go** (version 1.22+)
+- **Go** (version 1.26+, matching `go.mod`)
 - **Minikube** or **Kind**
 - **Helm**
 

--- a/docs/application-readiness.md
+++ b/docs/application-readiness.md
@@ -31,7 +31,7 @@ For deployment-mode adoption gates, see `docs/production-adoption-checklist.md`.
 
 Prerequisites:
 
-- Go 1.22 or newer for normal development.
+- Go 1.26 or newer for normal development (the authoritative toolchain version is `go.mod`).
 - Helm for chart validation.
 - Docker with Buildx for container image validation.
 - Minikube or Kind for local Kubernetes validation.
@@ -56,14 +56,14 @@ go test -v -race -coverprofile=cover.out ./...
 Official images are published to Docker Hub and GitHub Container Registry. The current README documents:
 
 ```bash
-docker pull thelisdeep/pii-shield:v2.0.5
-docker pull ghcr.io/pii-shield/pii-shield:v2.0.5
+docker pull thelisdeep/pii-shield:2.1.1
+docker pull ghcr.io/pii-shield/pii-shield:2.1.1
 ```
 
 Smoke test example:
 
 ```bash
-echo "Error: User password=MySecretPass123! failed login" | docker run -i --rm ghcr.io/pii-shield/pii-shield:v2.0.5
+echo "Error: User password=MySecretPass123! failed login" | docker run -i --rm ghcr.io/pii-shield/pii-shield:2.1.1
 ```
 
 ### Kubernetes And Helm

--- a/operator/README.md
+++ b/operator/README.md
@@ -44,7 +44,7 @@ Once installed, you can protect any application by applying a `PiiPolicy` and ad
 
    | Mode | Status | Description |
    |------|--------|-------------|
-   | `file` | Stable (default) | The sidecar tails a log file on a shared `emptyDir` volume. Recommended for production. |
+   | `file` | Controlled rollout (default) | The sidecar tails a log file on a shared `emptyDir` volume. The recommended path; gate production use with [docs/production-adoption-checklist.md](../docs/production-adoption-checklist.md). |
    | `pipe` | **Experimental** | Rewrites the target container command through `/bin/sh -c` to redirect output into a named pipe. Can break distroless images (no shell), argument quoting, signal handling, and the app lifecycle. The webhook returns a warning on injection. Not recommended for production. |
    | `ebpf` | Experimental / R&D | Kernel-level interception prototype. Not production-ready. |
 
@@ -154,7 +154,7 @@ If you want to contribute to the Operator:
 > The Kustomize and `make deploy` paths in this directory are for local development, CRD generation, and manual validation of the operator source tree. For user-facing v2.x installs, use the Helm chart.
 
 ### Prerequisites
-- Go version v1.24+
+- Go version 1.26+ (matching the repository `go.mod`)
 - Docker version 17.03+
 - kubectl and access to a K8s cluster (e.g. Minikube)
 

--- a/tests/deployments/README.md
+++ b/tests/deployments/README.md
@@ -4,7 +4,7 @@ Each deployment path has its own folder with a focused `run.sh`.
 
 Shared utilities live in `shared/`:
 
-- `shared/replay-image`: local replay app image that bakes in the resolved `access.log` fixture (default `notes/log_example/access.log`, overridable with `PII_SHIELD_ACCESS_LOG`).
+- `shared/replay-image`: local replay app image that bakes in the resolved `access.log` fixture. Set `PII_SHIELD_ACCESS_LOG` to the path of a local representative log file (the fixture is kept outside this repository and is not committed).
 - `shared/scripts/common.sh`: common helpers for fixture checks, image loading, replay pod deployment, log collection, and assertions.
 
 ## Operator paths
@@ -120,7 +120,7 @@ Supported variables for Docker/local-binary paths:
 
 Standalone Helm paths map supported chart variables to `piiConfig.*` and `metrics.*`.
 Node/Python WASM SDK paths map `PII_SALT`, `PII_ENTROPY_THRESHOLD`, `PII_CONFIDENCE_THRESHOLD`, and `PII_FAIL_POLICY`.
-Operator paths currently map only `PII_FAIL_POLICY` to `PiiPolicy.spec.failPolicy`; other scanner env vars are not passed to injected sidecars by the current operator API.
+Operator path scripts currently map only `PII_FAIL_POLICY` to `PiiPolicy.spec.failPolicy`. The operator API itself supports the full scanner configuration surface (salt, thresholds, sensitive keys, regex lists) through `PiiPolicy` fields — see [Scanner Configuration via PiiPolicy](../../operator/README.md#scanner-configuration-via-piipolicy); the test scripts just do not template those fields yet.
 
 ## Prometheus metrics
 


### PR DESCRIPTION
Fixes six documentation drift items found during a systematic docs audit:

- docs/application-readiness.md: docker examples updated v2.0.5 → 2.1.1 (real tags have no v prefix); "Go 1.22 or newer" → "Go 1.26 or newer" pointing at go.mod as the authoritative source.
- CONTRIBUTING.md: Go prerequisite 1.22+ → 1.26+, matching go.mod.
- operator/README.md: Go prerequisite v1.24+ → 1.26+; file injection mode relabeled from "Stable … Recommended for production" to "Controlled rollout (default)" to match the normative readiness vocabulary in docs/production-adoption-checklist.md.
- CONFIGURATION.md: documents the previously missing PII_CONFIDENCE_THRESHOLD; replaces the abbreviated PII_SENSITIVE_KEYS default with the full 18-key list from DefaultConfig() and notes it replaces (not extends) defaults; adds a warning that invalid PII_CUSTOM_REGEX_LIST / PII_SAFE_REGEX_LIST input is fatal at startup (crash loop in sidecars).
- tests/deployments/README.md: removes the non-committable fixture path in favor of the PII_SHIELD_ACCESS_LOG convention; corrects the stale claim that the operator API can't pass scanner config to sidecars (it has since [#112](https://github.com/pii-shield/pii-shield/issues/112) — the test scripts just don't template those fields yet).

Docs-only change; scripts/set-version.sh --check passes; all referenced links/anchors verified.