### PR TITLE
Keep scanner 18-key default in standalone chart by emitting PII_SENSI…

### DIFF
--- a/charts/pii-shield/README.md
+++ b/charts/pii-shield/README.md
@@ -52,7 +52,7 @@ You can tune the redaction engine via `values.yaml` under `piiConfig`:
 | `requireStrongSalt` | string | `"false"` | Reject explicitly configured salts shorter than 16 bytes. |
 | `entropyThreshold` | string | `"3.6"` | Shannon entropy cut-off determining what is considered a "secret". |
 | `minSecretLength` | string | `"6"` | Minimum string length to apply entropy checks. |
-| `sensitiveKeys` | string | `"password,secret,token,key,api_key"` | Key names mapped to `key=value` parsers to aggressively redact. |
+| `sensitiveKeys` | string | `""` | Key names whose `key=value` values are always redacted. Empty keeps the scanner's built-in 18-key default; setting it **replaces** that default rather than extending it. |
 | `adaptiveThreshold` | string | `"false"` | Auto-tuning baselines based on standard traffic. |
 | `failPolicy` | string | `"open"` | Runtime failure policy. Use `"open"` to keep log flow alive, or `"closed"` to emit drop markers on processing failure. |
 

--- a/charts/pii-shield/templates/deployment.yaml
+++ b/charts/pii-shield/templates/deployment.yaml
@@ -88,8 +88,10 @@ spec:
               value: {{ .Values.piiConfig.entropyThreshold | quote }}
             - name: PII_MIN_SECRET_LENGTH
               value: {{ .Values.piiConfig.minSecretLength | quote }}
+            {{- if .Values.piiConfig.sensitiveKeys }}
             - name: PII_SENSITIVE_KEYS
               value: {{ .Values.piiConfig.sensitiveKeys | quote }}
+            {{- end }}
             - name: PII_ADAPTIVE_THRESHOLD
               value: {{ .Values.piiConfig.adaptiveThreshold | quote }}
             - name: PII_FAIL_POLICY

--- a/charts/pii-shield/values.yaml
+++ b/charts/pii-shield/values.yaml
@@ -90,8 +90,13 @@ piiConfig:
   # PII_MIN_SECRET_LENGTH: Minimum length of a string to be considered a candidate token
   minSecretLength: "6"
   
-  # PII_SENSITIVE_KEYS: Comma-separated list of keys to always redact values for
-  sensitiveKeys: "password,secret,token,key,api_key"
+  # PII_SENSITIVE_KEYS: Comma-separated list of keys whose values are always
+  # redacted. Leave empty to keep the scanner's built-in 18-key default
+  # (password, secret, token, key, cvv, cvc, auth, sign, api_key, apikey,
+  # access_token, client_secret, aws_access_key_id, aws_secret_access_key,
+  # gcp_credentials, slack_token, ...). Setting this REPLACES that default list
+  # rather than extending it, so include every key you want redacted.
+  sensitiveKeys: ""
   
   # PII_ADAPTIVE_THRESHOLD: Enable statistical learning
   adaptiveThreshold: "false"


### PR DESCRIPTION
…TIVE_KEYS only when set (GH-52)