### PR TITLE
Build cmd/cleaner as a package, not a single file

### DIFF
--- a/benchmark/run_benchmarks.sh
+++ b/benchmark/run_benchmarks.sh
@@ -124,14 +124,14 @@ echo "   Payload size: ${payload_mb_display} MiB"
 
 echo
 echo "2. Building current branch..."
-"${GO_BIN}" build -o "${new_bin}" ./cmd/cleaner/main.go
+"${GO_BIN}" build -o "${new_bin}" ./cmd/cleaner
 
 echo "3. Building baseline ${BASE_REF}..."
 tmp_baseline_dir="$(mktemp -d)"
 git archive "${base_sha}" | tar -x -C "${tmp_baseline_dir}"
 (
   cd "${tmp_baseline_dir}"
-  "${GO_BIN}" build -o "${old_bin}" ./cmd/cleaner/main.go
+  "${GO_BIN}" build -o "${old_bin}" ./cmd/cleaner
 )
 rm -rf "${tmp_baseline_dir}"
 tmp_baseline_dir=""

--- a/tests/deployments/local-binary/run.sh
+++ b/tests/deployments/local-binary/run.sh
@@ -9,7 +9,7 @@ enable_runtime_metrics_by_default
 prepare_pii_env_args
 
 mkdir -p "${repo_root}/bin"
-go build -o "${repo_root}/bin/pii-shield" "${repo_root}/cmd/cleaner/main.go"
+go build -o "${repo_root}/bin/pii-shield" "${repo_root}/cmd/cleaner"
 
 print_runtime_metrics_hint
 env "${pii_process_env_args[@]}" \


### PR DESCRIPTION
## Summary
- `cmd/cleaner` became multi-file (`stats.go` added in #130), but two build
  sites still compiled only `main.go`, silently dropping the rest of the
  package from the binary.
- Fixed `tests/deployments/local-binary/run.sh` to build `./cmd/cleaner` as
  a package.
- Fixed `benchmark/run_benchmarks.sh` (both the current-branch and baseline
  build lines) the same way.

## Test plan
- [x] `BASE_REF=origin/main RUNS=9 LINES=500000 ./benchmark/run_benchmarks.sh`
      runs end-to-end; new vs old median throughput within noise
      (14.13 vs 14.10 MiB/s) — confirms the fix doesn't regress performance.