### PR TITLE
fix(wasm): scan multi-line redact() input line by line, keep line end…

### DIFF
--- a/cmd/wasm-ffi/main.go
+++ b/cmd/wasm-ffi/main.go
@@ -131,8 +131,10 @@ func redact(ptr uint32, length uint32) uint64 {
 	b := unsafe.Slice((*byte)(unsafe.Pointer(uintptr(ptr))), length)
 	input := unsafe.String(&b[0], length)
 
-	// Process
-	redacted := scanner.ScanAndRedact(input)
+	// Process line by line: SDK callers pass whole documents (a git diff, a
+	// log batch), and the single-line engine would otherwise score the last
+	// token of every line together with its newline (#184).
+	redacted := scanner.ScanAndRedactText(input)
 	
 	outBytes := []byte(redacted)
 	var ptr32 uint32

--- a/pkg/scanner/multiline_test.go
+++ b/pkg/scanner/multiline_test.go
@@ -1,0 +1,96 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression tests for #184: the WASM SDKs pass whole documents to the
+// engine, and ScanAndRedact treats '\n' as an ordinary byte, so a value at
+// the end of a line was scored together with its newline and redacted as
+// entropy, with the newline swallowed by the marker. ScanAndRedactText scans
+// per line and preserves line endings.
+
+func newMultilineScanner(t *testing.T) *Scanner {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.Salt = []byte("multiline-test-salt-1234567890")
+	return NewScanner(cfg)
+}
+
+func TestScanAndRedactText_DecimalAtLineEndIsNotRedacted(t *testing.T) {
+	s := newMultilineScanner(t)
+	for _, in := range []string{
+		"4532015112.830366\n",
+		"+total,4532015112.830366\n",
+		"+total,4532015112.830366\r\n",
+		"+2,bob,20.25\n+total,4532015112.830366\n",
+		"a\n4532015112.830366",
+	} {
+		if got := s.ScanAndRedactText(in); got != in {
+			t.Errorf("ScanAndRedactText(%q) = %q, want input unchanged", in, got)
+		}
+	}
+}
+
+func TestScanAndRedactText_SingleLineMatchesScanAndRedact(t *testing.T) {
+	s := newMultilineScanner(t)
+	for _, in := range []string{
+		"",
+		"plain text",
+		"password=SuperSecretValue123",
+		"token=Zq8vN3pL7xR2wT9yB4mK6 and 4532015112.830366",
+	} {
+		if got, want := s.ScanAndRedactText(in), s.ScanAndRedact(in); got != want {
+			t.Errorf("ScanAndRedactText(%q) = %q, ScanAndRedact = %q", in, got, want)
+		}
+	}
+}
+
+func TestScanAndRedactText_EachLineIsScanned(t *testing.T) {
+	s := newMultilineScanner(t)
+	in := "line one\npassword=SuperSecretValue123\r\ntoken=Zq8vN3pL7xR2wT9yB4mK6\n\nlast"
+	got := s.ScanAndRedactText(in)
+	want := "line one\n" + s.ScanAndRedact("password=SuperSecretValue123") + "\r\n" +
+		s.ScanAndRedact("token=Zq8vN3pL7xR2wT9yB4mK6") + "\n\nlast"
+	if got != want {
+		t.Fatalf("got  %q\nwant %q", got, want)
+	}
+	if !strings.Contains(got, "[HIDDEN:") {
+		t.Fatalf("expected secrets on inner lines to be redacted, got %q", got)
+	}
+}
+
+func TestScanAndRedactText_PreservesLineCount(t *testing.T) {
+	s := newMultilineScanner(t)
+	diff := "diff --git a/report.csv b/report.csv\n" +
+		"index 3b18e51..a1c9f02 100644\n" +
+		"--- a/report.csv\n" +
+		"+++ b/report.csv\n" +
+		"@@ -1,3 +1,4 @@\n" +
+		" id,name,total\n" +
+		" 1,alice,10.5\n" +
+		"-2,bob,20.25\n" +
+		"+2,bob,20.25\n" +
+		"+total,4532015112.830366\n"
+	got := s.ScanAndRedactText(diff)
+	if strings.Count(got, "\n") != strings.Count(diff, "\n") {
+		t.Fatalf("line count changed: %d -> %d\n%s", strings.Count(diff, "\n"), strings.Count(got, "\n"), got)
+	}
+	if !strings.HasSuffix(got, "+total,4532015112.830366\n") {
+		t.Fatalf("decimal at end of last line was altered:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "\n") || strings.HasSuffix(got, "\n\n") {
+		t.Fatalf("trailing newline not preserved exactly: %q", got[len(got)-4:])
+	}
+}
+
+func TestScanAndRedactText_PackageLevelUsesGlobalConfig(t *testing.T) {
+	in := "x\n4532015112.830366\n"
+	if got := ScanAndRedactText(in); got != in {
+		t.Fatalf("ScanAndRedactText(%q) = %q, want unchanged", in, got)
+	}
+	if got := ScanAndRedactText("password=SuperSecretValue123\n"); got == "password=SuperSecretValue123\n" || !strings.HasSuffix(got, "\n") {
+		t.Fatalf("expected redaction with trailing newline kept, got %q", got)
+	}
+}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -762,6 +762,42 @@ func (st *configState) ScanAndRedact(logLine string) string {
 	return sb.String()
 }
 
+// ScanAndRedactText redacts text that may span several lines, scanning each
+// line on its own. ScanAndRedact is a single-line engine: '\n' is not a token
+// separator, so a value at the end of a line would otherwise be scored
+// together with its newline (and the first token of the next line). That
+// defeats structural safe rules such as isPlainDecimal and swallows the
+// newline inside the redaction marker, changing the line count (#184). Line
+// endings ("\n" and "\r\n") are preserved, so the output has exactly as
+// many lines as the input — the same contract the CLI gives stdin.
+func ScanAndRedactText(text string) string {
+	return cfgState().ScanAndRedactText(text)
+}
+
+// ScanAndRedactText is the multi-line counterpart of ScanAndRedact; Scanner
+// embeds *configState, so it is promoted as (*Scanner).ScanAndRedactText.
+func (st *configState) ScanAndRedactText(text string) string {
+	if strings.IndexByte(text, '\n') == -1 {
+		return st.ScanAndRedact(text)
+	}
+	var sb strings.Builder
+	sb.Grow(len(text) + 100)
+	for len(text) > 0 {
+		line, ending := text, ""
+		if i := strings.IndexByte(text, '\n'); i >= 0 {
+			line, ending, text = text[:i], "\n", text[i+1:]
+		} else {
+			text = ""
+		}
+		if strings.HasSuffix(line, "\r") {
+			line, ending = line[:len(line)-1], "\r"+ending
+		}
+		sb.WriteString(st.ScanAndRedact(line))
+		sb.WriteString(ending)
+	}
+	return sb.String()
+}
+
 // scanLine is the zero-allocation internal version of ScanAndRedact.
 // depth tracks nesting of the recursive token machinery (see
 // maxTokenRecursionDepth); top-level callers pass 0.

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -26,6 +26,8 @@ console.log(redactedText);
 // Output will have the high entropy token redacted
 ```
 
+`redact()` accepts multi-line text. Each line is scanned independently and `\n` / `\r\n` endings are preserved, so the output has exactly as many lines as the input (the same contract the CLI gives stdin).
+
 ## Configuration
 
 `PiiShield.create(config)` accepts these overrides. Any field left unset keeps

--- a/sdks/parity/cases.json
+++ b/sdks/parity/cases.json
@@ -67,5 +67,17 @@
     },
     "input": "ref A1b2C3d4E5f6G7h8x9K0mN random tail",
     "expected": "ref A1b2C3d4E5f6G7h8x9K0mN random tail"
+  },
+  {
+    "name": "multiline_decimal_at_line_end_not_redacted",
+    "config": {},
+    "input": "+2,bob,20.25\n+total,4532015112.830366\n",
+    "expected": "+2,bob,20.25\n+total,4532015112.830366\n"
+  },
+  {
+    "name": "multiline_secret_on_inner_line_redacted_line_count_kept",
+    "config": {},
+    "input": "line one\npassword=SuperSecretValue123\r\n4532015112.830366\n",
+    "expected": "line one\npassword=[HIDDEN:8836e2]\r\n4532015112.830366\n"
   }
 ]

--- a/sdks/parity/parity_test.go
+++ b/sdks/parity/parity_test.go
@@ -110,14 +110,15 @@ func loadCases(t *testing.T) []parityCase {
 	return cases
 }
 
-// TestGoParity asserts the Go API (scanner.ScanAndRedact) reproduces the golden
-// for every case. The Node and Python SDKs assert the same golden via WASM.
+// TestGoParity asserts the Go API (scanner.ScanAndRedactText, the entry point
+// the WASM kernel calls) reproduces the golden for every case. The Node and
+// Python SDKs assert the same golden via WASM.
 func TestGoParity(t *testing.T) {
 	for _, tc := range loadCases(t) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			scanner.UpdateConfig(applyConfig(t, tc.Config))
-			got := scanner.ScanAndRedact(tc.Input)
+			got := scanner.ScanAndRedactText(tc.Input)
 			if got != tc.Expected {
 				t.Fatalf("parity mismatch\n input:    %q\n config:   %v\n expected: %q\n got:      %q",
 					tc.Input, tc.Config, tc.Expected, got)

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -26,6 +26,8 @@ print(redacted_text)
 # Output might redact the high entropy secret based on context
 ```
 
+`redact()` accepts multi-line text. Each line is scanned independently and `\n` / `\r\n` endings are preserved, so the output has exactly as many lines as the input (the same contract the CLI gives stdin).
+
 ## Configuration
 
 `PiiShieldConfig` accepts these overrides. Any field left unset keeps the core


### PR DESCRIPTION
Closes 
[#184](https://github.com/pii-shield/pii-shield/issues/184)
. The WASM redact export passed the whole input buffer to the single-line engine, so the last token of every line carried its newline (and often the first token of the next line). Structural safe rules such as isPlainDecimal never matched, the token fell through to the entropy scorer, and the newline was swallowed inside the marker, changing the line count. Reported downstream by a GitHub Action that feeds a full git diff to redact() in one call; reproduced on released 2.1.1 and 2.2.0 wheels.

Fix: new scanner.ScanAndRedactText scans per line and preserves \n / \r\n; cmd/wasm-ffi uses it. CLI behaviour unchanged. Parity golden gains two multi-line cases; Go, Python and Node parity all pass against the rebuilt WASM. Five regression tests in pkg/scanner/multiline_test.go. SDK READMEs document the multi-line contract.