### PR TITLE
fix(scanner): pass git diff header lines and hex..hex ranges through …

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -71,7 +71,7 @@ export PII_CUSTOM_REGEX_LIST='[{"pattern": "^[0-9a-fA-F-]{36}$", "name": "UUID"}
 ```
 
 > [!TIP]
-> **Priority:** Custom regexes are checked **before** entropy but **after** static safety whitelists. Use this to catch structured data like UUIDs or specific IDs that the entropy scanner might miss or consider "safe".
+> **Priority:** Custom regexes are checked **before** entropy but **after** static safety whitelists. The built-in static whitelists cover URLs, file paths, timestamps, UUIDs, git hashes and `abc1234..def5678` hash ranges, MongoDB ObjectIDs, SSH keys, plain decimal numbers, and whole `git diff` header lines (`diff --git`, `--- a/`, `+++ b/`, `rename`/`copy from|to`, `Binary files`); diff body lines are scanned normally. Use this to catch structured data like UUIDs or specific IDs that the entropy scanner might miss or consider "safe".
 > **Performance:** Regex checks are skipped for tokens shorter than 5 characters.
 
 > [!NOTE]

--- a/pkg/scanner/git_diff_header_test.go
+++ b/pkg/scanner/git_diff_header_test.go
@@ -1,0 +1,112 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression tests for #186: git diff header lines (a/ b/ relative paths,
+// abbreviated hash ranges) were redacted as entropy.
+
+func newDiffHeaderScanner(t *testing.T) *Scanner {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.Salt = []byte("diff-header-test-salt-1234567890")
+	return NewScanner(cfg)
+}
+
+func TestGitDiffHeaderLinesPassThrough(t *testing.T) {
+	s := newDiffHeaderScanner(t)
+	for _, line := range []string{
+		"diff --git a/report.csv b/report.csv",
+		"diff --git a/src/pkg/scanner/scanner_test.go b/src/pkg/scanner/scanner_test.go",
+		"diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml",
+		"diff --cc pkg/scanner/scanner.go",
+		"index 3b18e51..a1c9f02 100644",
+		"index 3b18e51f2c9d0a7..a1c9f02b4e8d1c3 100644",
+		"index 3b18e51f2c9d0a7b4e8d1c3f6a9b2c5d8e1f4a7b..a1c9f02b4e8d1c3f6a9b2c5d8e1f4a7b3b18e51f 100644",
+		"--- a/report.csv",
+		"+++ b/report.csv",
+		"--- a/b/Dockerfile",
+		"+++ b/lib/foo/bar.py",
+		"--- /dev/null",
+		"+++ /dev/null",
+		"rename from old/name.txt",
+		"rename to new/name.txt",
+		"copy from a/README.md",
+		"copy to b/README.md",
+		"Binary files a/logo.png and b/logo.png differ",
+	} {
+		if got := s.ScanAndRedact(line); got != line {
+			t.Errorf("ScanAndRedact(%q) = %q, want unchanged", line, got)
+		}
+	}
+}
+
+func TestGitDiffBodyLinesAreStillScanned(t *testing.T) {
+	s := newDiffHeaderScanner(t)
+	for _, line := range []string{
+		"+password=SuperSecretValue123",
+		"-password=SuperSecretValue123",
+		" token=Zq8vN3pL7xR2wT9yB4mK6",
+		"--- password=SuperSecretValue123",         // not a header: no a/ prefix
+		"+++ password=SuperSecretValue123",         // not a header: no b/ prefix
+		"diff password=SuperSecretValue123",        // not a header
+		"rename password=SuperSecretValue123",      // not a header
+		"\"--- a/x\" password=SuperSecretValue123", // header text quoted inside a value line
+	} {
+		got := s.ScanAndRedact(line)
+		if !strings.Contains(got, "[HIDDEN:") || strings.Contains(got, "SuperSecretValue123") || strings.Contains(got, "Zq8vN3pL7xR2wT9yB4mK6") {
+			t.Errorf("ScanAndRedact(%q) = %q, want the secret redacted", line, got)
+		}
+	}
+}
+
+func TestIsGitHashRange(t *testing.T) {
+	yes := []string{"3b18e51..a1c9f02", "3b18e51...a1c9f02", "3b18e51f2c9d0a7..a1c9f02b4e8d1c3",
+		strings.Repeat("a", 40) + ".." + strings.Repeat("b", 40)}
+	no := []string{"abc..def", "3b18e51..notahex", "3b18e51.a1c9f02", "3b18e51..", "..a1c9f02",
+		strings.Repeat("a", 41) + ".." + strings.Repeat("b", 40), "3b18e51..a1c9f02..deadbee", "Zq8vN3pL7xR2wT9yB4mK6"}
+	for _, tok := range yes {
+		if !isGitHashRange(tok) {
+			t.Errorf("isGitHashRange(%q) = false, want true", tok)
+		}
+	}
+	for _, tok := range no {
+		if isGitHashRange(tok) {
+			t.Errorf("isGitHashRange(%q) = true, want false", tok)
+		}
+	}
+}
+
+func TestGitDiffLineByLineKeepsHeadersRedactsBody(t *testing.T) {
+	s := newDiffHeaderScanner(t)
+	diff := "diff --git a/config.env b/config.env\n" +
+		"index 3b18e51..a1c9f02 100644\n" +
+		"--- a/config.env\n" +
+		"+++ b/config.env\n" +
+		"@@ -1,2 +1,2 @@\n" +
+		" APP_NAME=demo\n" +
+		"-password=OldSecretValue123\n" +
+		"+password=SuperSecretValue123\n"
+	// Line by line, as the CLI reads stdin (multi-line WASM input is #184).
+	var out strings.Builder
+	for _, line := range strings.SplitAfter(diff, "\n") {
+		out.WriteString(s.ScanAndRedact(strings.TrimSuffix(line, "\n")))
+		if strings.HasSuffix(line, "\n") {
+			out.WriteString("\n")
+		}
+	}
+	got := out.String()
+	if strings.Count(got, "\n") != strings.Count(diff, "\n") {
+		t.Fatalf("line count changed:\n%s", got)
+	}
+	for _, header := range []string{"diff --git a/config.env b/config.env\n", "index 3b18e51..a1c9f02 100644\n", "--- a/config.env\n", "+++ b/config.env\n", "@@ -1,2 +1,2 @@\n", " APP_NAME=demo\n"} {
+		if !strings.Contains(got, header) {
+			t.Errorf("header/context line %q altered:\n%s", header, got)
+		}
+	}
+	if strings.Contains(got, "OldSecretValue123") || strings.Contains(got, "SuperSecretValue123") {
+		t.Fatalf("body secrets leaked:\n%s", got)
+	}
+}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1634,10 +1634,7 @@ func isGitHashRange(token string) bool {
 	if i < 7 {
 		return false
 	}
-	rest := token[i+2:]
-	if strings.HasPrefix(rest, ".") {
-		rest = rest[1:]
-	}
+	rest := strings.TrimPrefix(token[i+2:], ".")
 	return isAbbrevHash(token[:i]) && isAbbrevHash(rest)
 }
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -770,6 +770,15 @@ func (st *configState) scanLine(logLine string, sb *strings.Builder, depth int) 
 		return
 	}
 
+	// Git diff header lines carry file paths and object hashes only, never
+	// values, and their a/ b/ relative paths and abbreviated hash ranges
+	// score above the entropy threshold (#186). Structural rule, top level
+	// only: a header is a whole line, not a quoted fragment inside one.
+	if depth == 0 && isGitDiffHeader(logLine) {
+		sb.WriteString(logLine)
+		return
+	}
+
 	// JSON lines are handled by the tokenizer itself (quotes, braces, colon
 	// pairs) — deliberately no encoding/json parse here; see compact_json_test.go.
 
@@ -1434,7 +1443,7 @@ func isSafe(token string) bool {
 		return true
 	}
 
-	if isPath(token) || isGitHash(token) || isMongoObjectID(token) {
+	if isPath(token) || isGitHash(token) || isGitHashRange(token) || isMongoObjectID(token) {
 		return true
 	}
 
@@ -1579,6 +1588,59 @@ func isPath(token string) bool {
 
 func isGitHash(token string) bool {
 	return len(token) == 40 && isHexStr(token)
+}
+
+// isGitHashRange reports whether token is a git object range such as
+// 3b18e51..a1c9f02 (the `index` line of a diff, `git log A..B`): two
+// hex runs of 7 to 40 characters joined by ".." or "...".
+func isGitHashRange(token string) bool {
+	i := strings.Index(token, "..")
+	if i < 7 {
+		return false
+	}
+	rest := token[i+2:]
+	if strings.HasPrefix(rest, ".") {
+		rest = rest[1:]
+	}
+	return isAbbrevHash(token[:i]) && isAbbrevHash(rest)
+}
+
+func isAbbrevHash(s string) bool {
+	return len(s) >= 7 && len(s) <= 40 && isHexStr(s)
+}
+
+// gitDiffHeaderPrefixes are the line starts of the `git diff` header
+// grammar that carry paths or hashes: the file pair, the old/new markers
+// (prefixed or /dev/null), renames and copies, and the binary-file notice.
+// Body lines ("+", "-", " ") are deliberately absent — they are scanned.
+var gitDiffHeaderPrefixes = [...]string{
+	"diff --git ",
+	"diff --cc ",
+	"diff --combined ",
+	"--- a/",
+	"+++ b/",
+	"--- \"a/",
+	"+++ \"b/",
+	"--- /dev/null",
+	"+++ /dev/null",
+	"rename from ",
+	"rename to ",
+	"copy from ",
+	"copy to ",
+	"Binary files ",
+}
+
+// isGitDiffHeader reports whether line is a git diff header line (see
+// gitDiffHeaderPrefixes). The `index <hash>..<hash> <mode>` line is not
+// listed: its range token is covered by isGitHashRange and the rest is
+// low-entropy.
+func isGitDiffHeader(line string) bool {
+	for _, p := range gitDiffHeaderPrefixes {
+		if strings.HasPrefix(line, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func isMongoObjectID(token string) bool {


### PR DESCRIPTION
Closes [#186](https://github.com/pii-shield/pii-shield/issues/186). Git diff header lines were redacted as entropy: a/ and b/ relative paths score above the 3.6 threshold (a/report.csv 3.92, b/Dockerfile 4.42) and the abbreviated 3b18e51..a1c9f02 range on the index line scores 4.58, so a sanitized diff lost every file name and stopped being a valid patch. Found while fixing  [#184](https://github.com/pii-shield/pii-shield/issues/184)

Two structural safe rules, no threshold change: a top-level line starting with a git diff header (diff --git, --- a/, +++ b/, /dev/null markers, rename/copy from|to, Binary files) is passed through unchanged; a <hex7-40>..<hex7-40> token is treated like a git hash. Body lines keep being scanned. Evidence: unit + race + 15s fuzz green; frozen labeled corpus from the corpus branch shows no new deviations; benchstat main vs branch (n=6) shows no significant change in time, bytes or allocs. Smoke not run (no Docker locally). CONFIGURATION.md lists the built-in whitelists.