### PR TITLE
fix(scanner): treat file names and relative paths with an extension a…

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -71,7 +71,7 @@ export PII_CUSTOM_REGEX_LIST='[{"pattern": "^[0-9a-fA-F-]{36}$", "name": "UUID"}
 ```
 
 > [!TIP]
-> **Priority:** Custom regexes are checked **before** entropy but **after** static safety whitelists. The built-in static whitelists cover URLs, file paths, timestamps, UUIDs, git hashes and `abc1234..def5678` hash ranges, MongoDB ObjectIDs, SSH keys, plain decimal numbers, and whole `git diff` header lines (`diff --git`, `--- a/`, `+++ b/`, `rename`/`copy from|to`, `Binary files`); diff body lines are scanned normally. Use this to catch structured data like UUIDs or specific IDs that the entropy scanner might miss or consider "safe".
+> **Priority:** Custom regexes are checked **before** entropy but **after** static safety whitelists. The built-in static whitelists cover URLs, file paths and file names with an extension (`report.csv`, `src/main.go`), timestamps, UUIDs, git hashes and `abc1234..def5678` hash ranges, MongoDB ObjectIDs, SSH keys, plain decimal numbers, and whole `git diff` header lines (`diff --git`, `--- a/`, `+++ b/`, `rename`/`copy from|to`, `Binary files`); diff body lines are scanned normally. Use this to catch structured data like UUIDs or specific IDs that the entropy scanner might miss or consider "safe".
 > **Performance:** Regex checks are skipped for tokens shorter than 5 characters.
 
 > [!NOTE]

--- a/pkg/scanner/filename_falsepos_test.go
+++ b/pkg/scanner/filename_falsepos_test.go
@@ -1,0 +1,81 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression tests for #189: file names and relative paths with an extension
+// were redacted as entropy.
+
+func newFileNameScanner(t *testing.T) *Scanner {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.Salt = []byte("filename-test-salt-1234567890")
+	return NewScanner(cfg)
+}
+
+func TestIsFileName(t *testing.T) {
+	yes := []string{
+		"report.csv", "config.yaml", "README.md", "src/main.go", "lib/foo/bar.py",
+		"app/models/user.py", "package-lock.json", "invoice_2024.xlsx", "scanner_test.go",
+		"data.jsonl", "photo.JPG", "archive.tar.gz", "a.b", "x/y/z.c", "v2.2.1.md",
+	}
+	no := []string{
+		"Dockerfile", "Makefile", ".gitignore", "src/", "/etc/passwd", "./run.sh", "a//b.txt",
+		"1.2.3.4", "10.0.0.1", "v2.2.1", "3.14", "alice@example.com", "https://x.io/a.txt",
+		"key=value.txt", "a:b.txt", "file..txt", "report.sqlite", "report.",
+		"Zq8vN3pL7xR2wT9yB4mK6",
+		"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+		"KEY.ngeVfQFYQlKU0ufo8x5d1A.TwL2iGABf9DHoTf-09kqeF8tAmbihYzrnopKc-1s5cr",
+		strings.Repeat("a", 260) + ".txt",
+	}
+	for _, tok := range yes {
+		if !isFileName(tok) {
+			t.Errorf("isFileName(%q) = false, want true", tok)
+		}
+	}
+	for _, tok := range no {
+		if isFileName(tok) {
+			t.Errorf("isFileName(%q) = true, want false", tok)
+		}
+	}
+}
+
+func TestFileNamesAreNotRedacted(t *testing.T) {
+	s := newFileNameScanner(t)
+	for _, line := range []string{
+		"report.csv",
+		"src/main.go",
+		"invoice_2024.xlsx",
+		"package-lock.json",
+		`Traceback: File "app/services/billing.py", line 42, in charge`,
+		"ERROR main.go:42 failed to open report.csv",
+		"uploaded invoice_2024.xlsx to bucket",
+		"modified: src/pkg/scanner/scanner_test.go",
+		"+++ b/config.yaml",
+		"-import lib/foo/bar.py",
+	} {
+		if got := s.ScanAndRedact(line); got != line {
+			t.Errorf("ScanAndRedact(%q) = %q, want unchanged", line, got)
+		}
+	}
+}
+
+func TestFileNameRuleDoesNotHideSecrets(t *testing.T) {
+	s := newFileNameScanner(t)
+	for _, tc := range []struct{ line, secret string }{
+		{"password=secret.txt", "secret.txt"}, // sensitive key forces redaction before isSafe
+		{"api_key=Zq8vN3pL7xR2wT9yB4mK6.key", "Zq8vN3pL7xR2wT9yB4mK6.key"},
+		{"token: Zq8vN3pL7xR2wT9yB4mK6", "Zq8vN3pL7xR2wT9yB4mK6"},
+		{"jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c", "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"},
+		{"apikey KEY.ngeVfQFYQlKU0ufo8x5d1A.TwL2iGABf9DHoTf-09kqeF8tAmbihYzrnopKc-1s5cr", "TwL2iGABf9DHoTf"},
+		{"contact alice@example.com now", "alice@example.com"},
+		{"card 4532015112830366", "4532015112830366"},
+	} {
+		got := s.ScanAndRedact(tc.line)
+		if strings.Contains(got, tc.secret) {
+			t.Errorf("ScanAndRedact(%q) = %q, secret %q survived", tc.line, got, tc.secret)
+		}
+	}
+}

--- a/pkg/scanner/filename_falsepos_test.go
+++ b/pkg/scanner/filename_falsepos_test.go
@@ -19,12 +19,12 @@ func TestIsFileName(t *testing.T) {
 	yes := []string{
 		"report.csv", "config.yaml", "README.md", "src/main.go", "lib/foo/bar.py",
 		"app/models/user.py", "package-lock.json", "invoice_2024.xlsx", "scanner_test.go",
-		"data.jsonl", "photo.JPG", "archive.tar.gz", "a.b", "x/y/z.c", "v2.2.1.md",
+		"data.jsonl", "photo.JPG", "archive.tar.gz", "a.b", "x/y/z.c", "v2.2.1.md", "video.mp4", "model.h5",
 	}
 	no := []string{
 		"Dockerfile", "Makefile", ".gitignore", "src/", "/etc/passwd", "./run.sh", "a//b.txt",
 		"1.2.3.4", "10.0.0.1", "v2.2.1", "3.14", "alice@example.com", "https://x.io/a.txt",
-		"key=value.txt", "a:b.txt", "file..txt", "report.sqlite", "report.",
+		"key=value.txt", "a:b.txt", "file..txt", "report.sqlite", "report.", "report.c-v", "a.t_x", "x.1a",
 		"Zq8vN3pL7xR2wT9yB4mK6",
 		"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 		"KEY.ngeVfQFYQlKU0ufo8x5d1A.TwL2iGABf9DHoTf-09kqeF8tAmbihYzrnopKc-1s5cr",

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1479,7 +1479,7 @@ func isSafe(token string) bool {
 		return true
 	}
 
-	if isPath(token) || isGitHash(token) || isGitHashRange(token) || isMongoObjectID(token) {
+	if isPath(token) || isFileName(token) || isGitHash(token) || isGitHashRange(token) || isMongoObjectID(token) {
 		return true
 	}
 
@@ -1593,6 +1593,63 @@ func isIPv6(token string) bool {
 	}
 	return false
 }
+
+// isFileName reports whether token has the shape of a file name or relative
+// path with an extension: report.csv, src/main.go, app/models/user.py,
+// invoice_2024.xlsx. isPath covers absolute and Windows paths only, so these
+// were scored on entropy, where "." "/" "_" add class bonus on top of the
+// letters and digits and push most real names over the threshold (#189).
+//
+// The shape is deliberately narrow so that no known secret format fits it:
+// only [A-Za-z0-9._/-] (no "=", "+", ":", "@"), a non-empty stem, and a last
+// "."-separated extension of 1 to 5 alphanumerics starting with a letter.
+// JWTs and SendGrid-style keys have long base64 segments after their last
+// dot, IPv4 addresses and version strings end in digits, e-mails carry "@",
+// URLs are handled before this rule. Extensionless names (Dockerfile,
+// Makefile) and dot-files with an empty stem (.gitignore) do not match.
+func isFileName(token string) bool {
+	if len(token) < 3 || len(token) > 256 || token[0] == '.' && token[1] == '/' {
+		return false // "./x" and "../x" are isPath's job
+	}
+	if strings.IndexByte(token, '.') < 0 {
+		return false // no extension possible; cheap exit for the common token
+	}
+	lastDot, lastSlash := -1, -1
+	for i := 0; i < len(token); i++ {
+		c := token[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '_', c == '-':
+		case c == '.':
+			if i > 0 && token[i-1] == '.' {
+				return false // "file..txt", "../x"
+			}
+			lastDot = i
+		case c == '/':
+			if i == 0 || token[i-1] == '/' {
+				return false // absolute paths are isPath's job; "//" is not a path
+			}
+			lastSlash = i
+		default:
+			return false
+		}
+	}
+	if lastDot <= lastSlash+1 {
+		return false // no extension in the last segment, or a dot-file with an empty stem
+	}
+	ext := token[lastDot+1:]
+	if len(ext) == 0 || len(ext) > 5 || !isASCIILetter(ext[0]) {
+		return false
+	}
+	for i := 1; i < len(ext); i++ {
+		if !isASCIILetter(ext[i]) && !isASCIIDigit(ext[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIILetter(c byte) bool { return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' }
+func isASCIIDigit(c byte) bool  { return c >= '0' && c <= '9' }
 
 func isPath(token string) bool {
 	// Unix Paths


### PR DESCRIPTION
Closes [#189](https://github.com/pii-shield/pii-shield/issues/189). report.csv, config.yaml, src/main.go, invoice_2024.xlsx and similar tokens scored above the 3.6 threshold and were redacted as entropy in Python tracebacks, build logs, git status output and diff bodies. isPath only knew absolute and Windows paths.

New structural safe rule isFileName: [A-Za-z0-9._/-] only, non-empty stem, last .-extension of 1–5 alphanumerics starting with a letter; ./, ../, //, .., dot-files and extensionless names excluded. No known secret format fits the shape (JWT/SendGrid-style keys have long base64 last segments, IPv4 and versions end in digits, e-mails carry @, URLs are handled earlier). Sensitive-key positions still force redaction before isSafe. Trade-off documented in code: a secret-shaped stem with an extension in free text is treated as a file name.

Evidence: unit + race + 15s fuzz green; frozen labeled corpus shows no new deviations; alternating benchstat main vs branch (n=10) shows no change (ScanAndRedact p=0.97, Throughput p=1.0). Smoke not run (no Docker locally). CONFIGURATION.md updated.