### PR TITLE
fix(scanner): score a diff body line without its leading +/- marker (#192)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -71,7 +71,7 @@ export PII_CUSTOM_REGEX_LIST='[{"pattern": "^[0-9a-fA-F-]{36}$", "name": "UUID"}
 ```
 
 > [!TIP]
-> **Priority:** Custom regexes are checked **before** entropy but **after** static safety whitelists. The built-in static whitelists cover URLs, file paths and file names with an extension (`report.csv`, `src/main.go`), timestamps, UUIDs, git hashes and `abc1234..def5678` hash ranges, MongoDB ObjectIDs, SSH keys, plain decimal numbers, and whole `git diff` header lines (`diff --git`, `--- a/`, `+++ b/`, `rename`/`copy from|to`, `Binary files`); diff body lines are scanned normally. Use this to catch structured data like UUIDs or specific IDs that the entropy scanner might miss or consider "safe".
+> **Priority:** Custom regexes are checked **before** entropy but **after** static safety whitelists. The built-in static whitelists cover URLs, file paths and file names with an extension (`report.csv`, `src/main.go`), timestamps, UUIDs, git hashes and `abc1234..def5678` hash ranges, MongoDB ObjectIDs, SSH keys, plain decimal numbers, and whole `git diff` header lines (`diff --git`, `--- a/`, `+++ b/`, `rename`/`copy from|to`, `Binary files`); diff body lines are scanned normally. On a diff body line the leading `+` / `-` marker is treated as framing rather than data: it is emitted verbatim and the rest of the line is scored on its own, so `+report.csv` scores like `report.csv`. Use this to catch structured data like UUIDs or specific IDs that the entropy scanner might miss or consider "safe".
 > **Performance:** Regex checks are skipped for tokens shorter than 5 characters.
 
 > [!NOTE]

--- a/pkg/scanner/diff_marker_test.go
+++ b/pkg/scanner/diff_marker_test.go
@@ -1,0 +1,94 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression tests for #192: a diff marker glued to the first token of a line
+// was scored as part of that token, so the marker's character class pushed
+// ordinary words and file names over the entropy threshold.
+
+func newMarkerScanner(t *testing.T) *Scanner {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.Salt = []byte("diff-marker-test-salt-1234567890")
+	return NewScanner(cfg)
+}
+
+func TestGluedDiffMarkerDoesNotRedactOrdinaryTokens(t *testing.T) {
+	s := newMarkerScanner(t)
+	for _, line := range []string{
+		"+report.csv", "+config.yaml", "+src/main.go", "+Traceback",
+		"-report.csv", "-config.yaml", "-src/main.go", "-Traceback",
+		"++report.csv", "--report.csv", "+see report.csv for totals",
+		"+import lib/foo/bar.py", "+total,4532015112.830366", "+2,bob,20.25",
+	} {
+		if got := s.ScanAndRedact(line); got != line {
+			t.Errorf("ScanAndRedact(%q) = %q, want unchanged", line, got)
+		}
+	}
+}
+
+func TestGluedDiffMarkerKeepsSecretsRedacted(t *testing.T) {
+	s := newMarkerScanner(t)
+	for _, tc := range []struct{ line, secret string }{
+		{"+password=SuperSecretValue123", "SuperSecretValue123"},
+		{"-password=SuperSecretValue123", "SuperSecretValue123"},
+		{"+AKIAIOSFODNN7EXAMPLE", "AKIAIOSFODNN7EXAMPLE"},
+		{"+Zq8vN3pL7xR2wT9yB4mK6", "Zq8vN3pL7xR2wT9yB4mK6"},
+		{"+4532015112830366", "4532015112830366"},
+		{"+alice@example.com", "alice@example.com"},
+		{"--flag=SuperSecretValue123", "SuperSecretValue123"},
+	} {
+		got := s.ScanAndRedact(tc.line)
+		if strings.Contains(got, tc.secret) {
+			t.Errorf("ScanAndRedact(%q) = %q, secret %q survived", tc.line, got, tc.secret)
+		}
+	}
+}
+
+// The marker itself must reach the output untouched, or a sanitized diff stops
+// being a valid patch.
+func TestGluedDiffMarkerIsPreservedInOutput(t *testing.T) {
+	s := newMarkerScanner(t)
+	for _, tc := range []struct{ line, prefix string }{
+		{"+password=SuperSecretValue123", "+"},
+		{"-password=SuperSecretValue123", "-"},
+		{"+Zq8vN3pL7xR2wT9yB4mK6", "+"},
+		{"++Zq8vN3pL7xR2wT9yB4mK6", "++"},
+	} {
+		if got := s.ScanAndRedact(tc.line); !strings.HasPrefix(got, tc.prefix) {
+			t.Errorf("ScanAndRedact(%q) = %q, want prefix %q", tc.line, got, tc.prefix)
+		}
+	}
+	for _, line := range []string{"+", "-", "++", "--", "---"} {
+		if got := s.ScanAndRedact(line); got != line {
+			t.Errorf("ScanAndRedact(%q) = %q, want unchanged", line, got)
+		}
+	}
+}
+
+// Deliberate behaviour change recorded in #192: a bare signed integer was
+// redacted only because of the sign; the unsigned form never was. Pinned here
+// so the change is explicit rather than incidental.
+func TestSignedBareIntegersAreNotRedacted(t *testing.T) {
+	s := newMarkerScanner(t)
+	for _, in := range []string{"-123456789", "-123456789012", "+123456789012", "123456789", "123456789012"} {
+		if got := s.ScanAndRedact(in); got != in {
+			t.Errorf("ScanAndRedact(%q) = %q, want unchanged", in, got)
+		}
+	}
+}
+
+func TestGitDiffHeadersStillPassThrough(t *testing.T) {
+	s := newMarkerScanner(t)
+	for _, line := range []string{
+		"--- a/report.csv", "+++ b/report.csv", "--- /dev/null",
+		"diff --git a/report.csv b/report.csv", "index 3b18e51..a1c9f02 100644",
+	} {
+		if got := s.ScanAndRedact(line); got != line {
+			t.Errorf("ScanAndRedact(%q) = %q, want unchanged", line, got)
+		}
+	}
+}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -815,6 +815,24 @@ func (st *configState) scanLine(logLine string, sb *strings.Builder, depth int) 
 		return
 	}
 
+	// A diff body line carries its marker glued to the first token: "+" and
+	// "-" are not token separators, so "+report.csv" reached the scorer as one
+	// token and the marker contributed a character class to the class bonus
+	// ("Traceback" scores 1.73, "+Traceback" 3.92 against a 3.6 threshold).
+	// The marker is framing, not data: emit it verbatim and score the rest of
+	// the line on its own (#192). At most two, for combined diffs (diff --cc).
+	// Output stays byte-for-byte, so line counts and patch validity hold.
+	if depth == 0 {
+		n := 0
+		for n < 2 && n < len(logLine) && (logLine[n] == '+' || logLine[n] == '-') {
+			n++
+		}
+		if n > 0 && n < len(logLine) {
+			sb.WriteString(logLine[:n])
+			logLine = logLine[n:]
+		}
+	}
+
 	// JSON lines are handled by the tokenizer itself (quotes, braces, colon
 	// pairs) — deliberately no encoding/json parse here; see compact_json_test.go.
 


### PR DESCRIPTION
Closes #192.

`+` and `-` are not token separators, so `+report.csv` reached the scorer as a single token and the marker contributed a character class to the class bonus. The effect is large on short low-entropy tokens: `Traceback` scores 1.73, `+Traceback` scores 3.92 against the 3.6 default threshold. `-report.csv` was clean only by accident, since `-` is a legal file-name character and matches `isFileName` while `+` cannot.

The fix emits a leading run of at most two `+` / `-` bytes verbatim (two, for combined `diff --cc` output) and scores the rest of the line on its own. The marker is diff framing, not data. Output stays byte-for-byte, so line counts and patch validity are unaffected, and the git diff header check still runs first.

Detection is preserved wherever the remainder alone is detected — covered by a test: `+password=…`, `-password=…`, `+AKIAIOSFODNN7EXAMPLE`, `+Zq8vN3pL7xR2wT9yB4mK6`, `+4532015112830366`, `+alice@example.com`, `--flag=…`.

**Deliberate behaviour change, pinned by `TestSignedBareIntegersAreNotRedacted`:** a bare signed integer is no longer redacted. `-123456789012` and `-123456789` were redacted while the unsigned `123456789012` and `123456789` were not, so the redaction came from the sign rather than the digits; all four are now clean. The engine never detected the unsigned form, so this removes an inconsistency rather than a detection. Called out in the issue and in the note going to the downstream reporter, who had listed those values.

Out of scope: `+Dockerfile` stays redacted because bare `Dockerfile` is redacted — extensionless file names were deliberately left out of #189 and are unchanged here.

Evidence: `go test ./...`, `-race` on `pkg/scanner`, golangci-lint and `go vet` all clean; 15 s `FuzzScanner` with no failures; the frozen labeled corpus shows no new deviations; alternating benchstat main vs branch (n=10) shows no measurable change (ScanAndRedact p=0.31, Throughput p=0.35, allocations identical). Smoke not run — no Docker daemon on this machine. CONFIGURATION.md documents the marker handling.