### PR TITLE
fix(scanner): score bigrams only on adjacent ASCII pairs (F5)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -33,7 +33,7 @@ Set `PII_REQUIRE_STRONG_SALT=true` in production if you want startup to fail ins
 | `PII_ADAPTIVE_THRESHOLD` | Enable statistical learning. Scanner adjusts threshold based on traffic baseline. | `false` |
 | `PII_ADAPTIVE_SAMPLES` | Number of samples to collect before activating adaptive mode. | `100` |
 | `PII_DISABLE_BIGRAM_CHECK` | Disable English bigram validation. Set to `true` for non-English logs. | `false` |
-| `PII_BIGRAM_DEFAULT_SCORE` | Log-probability score for unknown bigrams. | `-7.0` |
+| `PII_BIGRAM_DEFAULT_SCORE` | Log-probability score for unknown bigrams. Only pairs of adjacent ASCII characters are scored, so text in a non-Latin script gets no bigram adjustment at all and this value cannot push it towards redaction. | `-7.0` |
 | `PII_ENTITY_TYPE_LABELS` | Emit `[HIDDEN:<type>:<hash>]` instead of `[HIDDEN:<hash>]`, where `<type>` names the detector that fired: `card` (Luhn), `key` (sensitive key), `context` (context keyword), `url` (URL parameter entropy), `regex` (unnamed custom rule), `entropy` (plain entropy). Named custom rules keep their own name as the label. The hash is unchanged, so enabling the flag does not break tag correlation. Accepts `1`/`true`/`yes`/`y`/`on`. | `false` |
 
 ## Runtime Failure Policy

--- a/pkg/scanner/bigram_utf8_test.go
+++ b/pkg/scanner/bigram_utf8_test.go
@@ -32,11 +32,35 @@ func TestBigramNonASCII(t *testing.T) {
 		st := cfgState()
 		for _, tok := range []string{
 			"конфигурация", "маршрутизация", "пользователь", "Аутентификация",
-			"соединение", "テスト環境",
+			"соединение", "пароль", "テスト環境",
 		} {
 			if got := st.calculateBigramAdjustment(tok); got != 0.0 {
 				t.Errorf("default %v, token %q: adjustment %v, want 0", defaultScore, tok, got)
 			}
+		}
+	}
+
+	// 1b. Mixed ASCII + multibyte tokens are scored on their ASCII runs, with
+	//     the pair that straddles a multibyte rune skipped. These cases used to
+	//     live in bigramEquivCorpus (hotpath_equiv_test.go), whose oracle is the
+	//     pre-F5 byte-slicing implementation; pinned here with explicit values
+	//     instead, since that oracle is what this change replaces.
+	for _, tc := range []struct {
+		token        string
+		defaultScore float64
+		want         float64
+	}{
+		{"mixedПароль123", -7.0, 0.0}, // "mi ix xe ed" + "12 23": neutral band
+		{"mixedПароль123", -9.0, 0.5}, // the digit pairs are unknown: random-looking
+		{"emoji🙂token", -7.0, 0.0},
+		{"emoji🙂token", -9.0, 0.0},
+	} {
+		cfg := campaignConfig()
+		cfg.BigramDefaultScore = tc.defaultScore
+		UpdateConfig(cfg)
+		if got := cfgState().calculateBigramAdjustment(tc.token); got != tc.want {
+			t.Errorf("default %v, token %q: adjustment %v, want %v",
+				tc.defaultScore, tc.token, got, tc.want)
 		}
 	}
 

--- a/pkg/scanner/bigram_utf8_test.go
+++ b/pkg/scanner/bigram_utf8_test.go
@@ -1,0 +1,79 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBigramNonASCII covers F5: the bigram table is English and byte-indexed,
+// so the pre-fix implementation sliced multibyte runes in half and scored every
+// non-Latin token as "all bigrams unknown" — i.e. as BigramDefaultScore. At the
+// default score (-7.0) that lands in the neutral band and hides the bug; at any
+// stricter custom score every Cyrillic word picked up the +0.5 "looks random"
+// boost and ordinary Russian text started to redact.
+//
+// After the fix only pairs of adjacent ASCII characters are scored, so a token
+// with no such pair gets no adjustment, and a Latin word carrying an accent
+// keeps the English-likeness bonus its ASCII run earns.
+//
+// Not fixed here (belongs to F6, the length-dependent threshold): Аутентификация
+// (3.825) and Днепропетровск (3.736) still exceed the 3.6 default threshold on
+// entropy plus class bonus alone, with no bigram contribution involved.
+func TestBigramNonASCII(t *testing.T) {
+	oldCfg := activeCfg()
+	defer UpdateConfig(oldCfg)
+
+	// 1. No adjustment for tokens that contain no adjacent ASCII pair, at the
+	//    default score and at a stricter custom one.
+	for _, defaultScore := range []float64{-7.0, -9.0} {
+		cfg := campaignConfig()
+		cfg.BigramDefaultScore = defaultScore
+		UpdateConfig(cfg)
+		st := cfgState()
+		for _, tok := range []string{
+			"конфигурация", "маршрутизация", "пользователь", "Аутентификация",
+			"соединение", "テスト環境",
+		} {
+			if got := st.calculateBigramAdjustment(tok); got != 0.0 {
+				t.Errorf("default %v, token %q: adjustment %v, want 0", defaultScore, tok, got)
+			}
+		}
+	}
+
+	// 2. End-to-end: at a stricter default score ordinary Russian text passes
+	//    through untouched. Verified pre-fix at -9.0: конфигурация scored 3.918
+	//    and маршрутизация 3.739, both over the 3.6 threshold.
+	cfg := campaignConfig()
+	cfg.BigramDefaultScore = -9.0
+	UpdateConfig(cfg)
+	for _, in := range []string{
+		"конфигурация",
+		"маршрутизация",
+		"пользователь авторизован успешно",
+	} {
+		if out := ScanAndRedact(in); out != in {
+			t.Errorf("Cyrillic false positive at BigramDefaultScore=-9.0: %q -> %q", in, out)
+		}
+	}
+
+	// 3. Accented Latin keeps the bonus its ASCII run earns, so a stricter
+	//    default score does not push German or French words over the threshold
+	//    either. (A plain "bail out on the first non-ASCII byte" fix would drop
+	//    these to 0 and raise every such word's score by 1.5.)
+	for _, tok := range []string{"Änderung", "übertragen", "réservation"} {
+		st := cfgState()
+		if got := st.calculateBigramAdjustment(tok); got != -1.5 {
+			t.Errorf("token %q: adjustment %v, want -1.5 (English-like ASCII run)", tok, got)
+		}
+		if out := ScanAndRedact(tok); out != tok {
+			t.Errorf("accented Latin false positive at BigramDefaultScore=-9.0: %q -> %q", tok, out)
+		}
+	}
+
+	// 4. Detection of a real secret next to non-ASCII text is unaffected.
+	UpdateConfig(campaignConfig())
+	out := ScanAndRedact("пароль AbC9xY2kQ8pLmN0r конец")
+	if strings.Contains(out, "AbC9xY2kQ8pLmN0r") || !strings.Contains(out, "[HIDDEN:") {
+		t.Errorf("secret next to Cyrillic text not redacted: %q", out)
+	}
+}

--- a/pkg/scanner/bigrams.go
+++ b/pkg/scanner/bigrams.go
@@ -5,7 +5,11 @@ package scanner
 //
 // LANGUAGE LIMITATION: This map is optimized for English text. Using this scanner
 // on non-English logs (German, Spanish, Chinese, etc.) or technical content (base64,
-// hex dumps) will result in higher false positive rates.
+// hex dumps) will result in higher false positive rates. Scoring covers pairs of
+// adjacent ASCII characters only: a word in a non-Latin script has no such pair and
+// therefore receives no adjustment in either direction, and an accented Latin word is
+// judged on the ASCII runs it does contain. The remaining false positives on such
+// text come from the entropy side, not from this table.
 //
 // CUSTOMIZATION: To support other languages, you have two options:
 // 1. Disable bigram checking entirely: Set PII_DISABLE_BIGRAM_CHECK=true

--- a/pkg/scanner/hotpath_equiv_test.go
+++ b/pkg/scanner/hotpath_equiv_test.go
@@ -145,10 +145,10 @@ var bigramEquivCorpus = []string{
 	"1234567890",
 	"user_id=42;q",
 	"key:value/path",
-	"пароль",         // non-ASCII: ToLower path
-	"Аутентификация", // non-ASCII with uppercase
-	"mixedПароль123", // mixed ASCII + multibyte
-	"emoji🙂token",    // multibyte non-letter
+	// Non-ASCII tokens used to live here too. F5 deliberately changed what the
+	// scanner does with them — byte-sliced bigrams cut multibyte runes in half —
+	// so the pre-O3 ToLower implementation is no longer the oracle for them.
+	// Their behavior is pinned in TestBigramNonASCII instead.
 	"ends-with-upperZ",
 	"Z@#$%^&*()aa",
 }
@@ -156,7 +156,7 @@ var bigramEquivCorpus = []string{
 // TestBigramInlineLowerEquivalence covers O3: the inline ASCII lowercase path
 // must return exactly what the ToLower-based implementation returns, at the
 // default config and at a custom BigramDefaultScore that activates the +0.5
-// branch; the non-ASCII path must stay byte-identical to before.
+// branch. Pure-ASCII tokens only: see the note on bigramEquivCorpus.
 func TestBigramInlineLowerEquivalence(t *testing.T) {
 	oldCfg := activeCfg()
 	defer UpdateConfig(oldCfg)

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -632,8 +632,7 @@ func (st *configState) calculateBigramAdjustment(token string) float64 {
 	if isASCIIString(token) {
 		// For pure-ASCII tokens strings.ToLower only maps A-Z, so an inline
 		// byte lowercase produces the same bigrams without the per-token
-		// allocation. Non-ASCII tokens keep the ToLower path: multibyte
-		// lowercasing changes bytes and must stay byte-identical to before.
+		// allocation.
 		prev := lowerASCIIByte(token[0])
 		for i := 1; i < len(token); i++ {
 			cur := lowerASCIIByte(token[i])
@@ -642,11 +641,25 @@ func (st *configState) calculateBigramAdjustment(token string) float64 {
 			prev = cur
 		}
 	} else {
-		sLower := strings.ToLower(token)
-		for i := 0; i < len(sLower)-1; i++ {
-			bg := sLower[i : i+2]
-			sumProb += st.bigramProb(bg) // Using shared bigram table from bigrams.go
-			count++
+		// The bigram table is English and byte-indexed, so taking bigrams two
+		// bytes at a time cuts multibyte runes in half: every pair read out of
+		// a Cyrillic (or any non-Latin) word is unknown by construction and the
+		// token collapses onto BigramDefaultScore no matter what it says. Score
+		// only the pairs whose characters are both ASCII and adjacent; a token
+		// with no such pair leaves count at 0 and gets no adjustment at all.
+		var prev byte
+		havePrev := false
+		for _, r := range token {
+			if r >= utf8.RuneSelf {
+				havePrev = false
+				continue
+			}
+			cur := lowerASCIIByte(byte(r))
+			if havePrev {
+				sumProb += st.bigramProbBytes(prev, cur)
+				count++
+			}
+			prev, havePrev = cur, true
 		}
 	}
 


### PR DESCRIPTION
The bigram table is English and byte-indexed, but the scorer walked the token two bytes at a time. On any non-Latin script that cuts multibyte runes in half, so every pair is unknown by construction and the whole token collapses onto `BigramDefaultScore` regardless of its content. At the default score (-7.0) that lands in the neutral band, which hid the bug; at a stricter custom score every Russian word picked up the +0.5 "looks random" boost and ordinary text started to redact.

Now only pairs of adjacent ASCII characters are scored. A token with no such pair gets no adjustment; an accented Latin word is still judged on the ASCII runs it contains, so it keeps the English-likeness bonus.

The simpler "bail out on the first non-ASCII byte" fix was measured and rejected: it drops that bonus and raises the score of words like `Änderung` by 1.5 (1.75 -> 3.25 against a 3.6 threshold), trading a Cyrillic fix for a German/French regression. `Straße` 3.085 -> 1.585 and `Prüfung` 3.307 -> 1.807 under the chosen fix, versus unchanged-then-worse under the bail-out.

## Evidence

- `go test -race -count=1 ./pkg/scanner/` — ok; `go build ./...`, `go vet ./pkg/scanner/`, `gofmt -l` all clean.
- New `TestBigramNonASCII`: no adjustment for Cyrillic/Japanese tokens at both -7.0 and -9.0; `конфигурация`, `маршрутизация` and `пользователь авторизован успешно` pass unredacted at -9.0; `Änderung`, `übertragen`, `réservation` keep the -1.5 bonus and stay unredacted; a secret next to Cyrillic text is still redacted.
- `redaction-diff.sh` vs `origin/main`, 200,000 lines of a real access log at default config: **0 differing lines**.
- `redaction-diff.sh` vs `origin/main`, 4,000-line multilingual corpus at `PII_BIGRAM_DEFAULT_SCORE=-9.0`: 593 differing lines, redaction markers 2044 -> 1433, **0 lines where the new build redacts more**, **0 secrets leaking** in either build (AWS key, GitHub token, card number, email, random token all still redacted).
- `scripts/test-smoke.sh`: Go tests and benchmarks green, the Docker accuracy stage did **not** run (Docker unavailable on this machine) — worth confirming in CI.

## Reviewer notes

- **Test expectation changed on purpose.** The four non-ASCII tokens were removed from `bigramEquivCorpus` in `hotpath_equiv_test.go`. That corpus asserts equivalence with the pre-O3 `strings.ToLower` implementation — exactly the behavior this change replaces — so it is no longer the oracle for them. Their behavior is now pinned in `TestBigramNonASCII`; the old test still guards the pure-ASCII inline-lowercase path.
- **Not fixed here:** `Аутентификация` (3.825) and `Днепропетровск` (3.736) still exceed the default 3.6 threshold on entropy plus class bonus alone, with no bigram contribution. That belongs to the length-dependent-threshold work (F6), not to this change.
- The non-ASCII branch also drops a `strings.ToLower` allocation per token; the pure-ASCII hot path is byte-identical to before.
- Docs: `CONFIGURATION.md` row for `PII_BIGRAM_DEFAULT_SCORE` and the language-limitation comment in `bigrams.go` now state that only adjacent ASCII pairs are scored.
- The new regression test counts as OpenSSF Workstream 4 evidence (false-positive regression tests) — account for it once.
