### PR TITLE
feat(scanner): redact issuer-prefixed secrets by signature (F1)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -48,7 +48,7 @@ See `docs/sidecar-failure-modes.md` for production failure-mode guidance.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `PII_METRICS_ENABLED` | Expose a Prometheus `/metrics` endpoint and a `/healthz` probe. | `false` |
+| `PII_METRICS_ENABLED` | Expose a Prometheus `/metrics` endpoint and a `/healthz` probe. The `piishield_redaction_events_total` counter carries a `type` label bounded to `entropy`, `regex`, `luhn`, `signature` and `unknown`; `signature` counts the built-in issuer-prefix detectors (AWS, Google, GitHub, Slack, Stripe, JWT, Bearer, PEM private keys). | `false` |
 | `PII_METRICS_PORT` | Port for the metrics/health server (1–65535). | `9090` |
 | `PII_STATS_LOG_INTERVAL` | When set to a positive Go duration (e.g. `1h`, `30m`), log a periodic aggregated redaction summary — counts of high-entropy secrets, pattern matches, and card numbers, plus lines and bytes processed — and a final summary on shutdown. Empty or invalid disables it. Independent of `PII_METRICS_ENABLED`. | _(disabled)_ |
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Developers often forget to mask sensitive data. Traditional regex filters in Flu
 - **Production-hardening Core Engine:** Optimized for Kubernetes sidecars with low memory allocations on hot paths and deterministic regex matching.
 - **Context-Aware Entropy Analysis:** Detected high-entropy secrets even without keys (e.g. `Error: ... 44saCk9...`) by analyzing context keywords.
 - **Custom Regex Rules:** Deterministic redaction for structured data (UUIDs, IDs) that overrides entropy checks for known patterns.
+- **Built-in Secret Signatures:** Issuer-prefixed credentials — AWS and Google API keys, GitHub, Slack and Stripe tokens, JWTs, `Bearer` credentials and PEM private-key blocks — are redacted on their format, so a valid key is caught even when its body is low-entropy or the threshold has been raised.
 - **Regression & Fuzz Coverage:** Tested against stress cases including binary garbage, JSON nesting, and multilingual logs.
 - **Deterministic Hashing:** Replaces secrets with unique hashes (e.g., `[HIDDEN:a1b2c]`), allowing QA to correlate errors without seeing the raw data.
 - **Drop-in:** No code changes required. Works with any language (Node, Python, Java, Go).

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -16,7 +16,7 @@ var (
 	RedactionEventsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "piishield_redaction_events_total",
 		Help: "Total number of secrets redacted",
-	}, []string{"type"}) // Strictly using "entropy", "regex", "luhn" to avoid high cardinality
+	}, []string{"type"}) // Strictly using "entropy", "regex", "luhn", "signature" to avoid high cardinality
 
 	// ProcessingDuration seconds tracks the time spent sanitizing logs.
 	ProcessingDuration = promauto.NewHistogram(prometheus.HistogramOpts{
@@ -35,7 +35,9 @@ var (
 // IncrementRedaction provides a safe interface to increment redactions
 // strictly bounding to specific values to avoid OOM or cardinality explosions.
 func IncrementRedaction(strategyType string) {
-	if strategyType != "entropy" && strategyType != "regex" && strategyType != "luhn" {
+	switch strategyType {
+	case "entropy", "regex", "luhn", "signature":
+	default:
 		strategyType = "unknown"
 	}
 	RedactionEventsTotal.WithLabelValues(strategyType).Inc()

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -14,6 +14,7 @@ func TestIncrementRedaction(t *testing.T) {
 	IncrementRedaction("entropy")
 	IncrementRedaction("regex")
 	IncrementRedaction("luhn")
+	IncrementRedaction("signature")
 
 	// Test invalid strategy mapping to "unknown"
 	IncrementRedaction("malicious-label")
@@ -31,6 +32,11 @@ func TestIncrementRedaction(t *testing.T) {
 	// Validate count for "luhn"
 	if count := testutil.ToFloat64(RedactionEventsTotal.WithLabelValues("luhn")); count != 1 {
 		t.Errorf("Expected 1 for luhn, got %v", count)
+	}
+
+	// Validate count for "signature"
+	if count := testutil.ToFloat64(RedactionEventsTotal.WithLabelValues("signature")); count != 1 {
+		t.Errorf("Expected 1 for signature, got %v", count)
 	}
 
 	// Validate fallback count for "unknown"

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -698,7 +698,8 @@ func lowerASCIIByte(b byte) byte {
 // entityLabel returns the entity-type label to embed in the redaction marker
 // when EntityTypeLabels is enabled, or "" for the legacy unlabeled format.
 // The set of types is deliberately small and fixed: card, key, context, url,
-// regex, entropy (named custom rules keep their own name instead).
+// regex, entropy, plus the issuer names of the built-in signature detectors in
+// signatures.go (named custom rules keep their own name instead).
 func (st *configState) entityLabel(entityType string) string {
 	if st.config.EntityTypeLabels {
 		return entityType
@@ -825,6 +826,16 @@ func (st *configState) scanLine(logLine string, sb *strings.Builder, depth int) 
 	// only: a header is a whole line, not a quoted fragment inside one.
 	if depth == 0 && isGitDiffHeader(logLine) {
 		sb.WriteString(logLine)
+		return
+	}
+
+	// The BEGIN/END framing of a PEM private key is a whole line with spaces in
+	// it, so no token ever carries the signature. Mark the line as a whole: it
+	// holds no secret itself, but it is what makes the event countable and
+	// attributable. The body lines are high-entropy base64 and are redacted by
+	// the entropy engine on their own.
+	if depth == 0 && isPrivateKeyMarker(logLine) {
+		st.redactWithHMAC(logLine, st.entityLabel("private-key"), "signature", sb)
 		return
 	}
 
@@ -1153,6 +1164,28 @@ func (st *configState) processSingleToken(content, original string, forcedSensit
 				}
 			}
 		}
+	}
+
+	// 2.5 Deterministic Check: built-in secret signatures. Runs after the user's
+	// own rules (so a custom rule or a safe rule still wins) but before the
+	// length, space and entropy heuristics, because a valid-format token with a
+	// low-entropy body — AKIA followed by sixteen A's — is a real key that the
+	// threshold would let through.
+	if label := matchSignature(content); label != "" {
+		quoteChar := byte(0)
+		if strings.HasPrefix(original, "\"") {
+			quoteChar = '"'
+		} else if strings.HasPrefix(original, "'") {
+			quoteChar = '\''
+		}
+		if quoteChar != 0 {
+			sb.WriteByte(quoteChar)
+		}
+		st.redactWithHMAC(content, st.entityLabel(label), "signature", sb)
+		if quoteChar != 0 {
+			sb.WriteByte(quoteChar)
+		}
+		return
 	}
 
 	// 3. Heuristics Check (Length & Spaces)
@@ -2063,6 +2096,8 @@ type segmentState struct {
 	// Generic KV Support
 	pendingGenericKey    bool // True if last key was "key", "name"
 	nextValueIsSensitive bool // True if "key"="password", so next "value" is sensitive
+
+	pendingBearer bool // True if the previous token was the "Bearer" auth scheme
 }
 
 func (st *configState) processAndAppend(token string, sb *strings.Builder, state *segmentState, depth int) {
@@ -2080,7 +2115,18 @@ func (st *configState) processAndAppend(token string, sb *strings.Builder, state
 	isGenericKeyName := lowerClean == "key" || lowerClean == "name" || lowerClean == "setting"
 
 	// 1. Process Token
-	isKey := st.processTokenLogic(token, state.pendingKeySensitive, state.pendingContextSensitive, state.isInValuePos, state.nextValueIsSensitive, sb, depth)
+	//
+	// "Authorization: Bearer <token>" has no key=value pair around the credential
+	// itself: the sensitive key spends its one forced slot on the word "Bearer"
+	// and the token after it goes free. Force that token too — but only when it
+	// is long enough to be a credential, so prose like "the bearer of this note"
+	// keeps its next word (the B1 lesson: a bare keyword must not redact
+	// ordinary text after it).
+	forced := state.pendingKeySensitive
+	if state.pendingBearer && len(cleanToken) >= minBearerCredentialLength {
+		forced = true
+	}
+	isKey := st.processTokenLogic(token, forced, state.pendingContextSensitive, state.isInValuePos, state.nextValueIsSensitive, sb, depth)
 	// sb is updated inside processTokenLogic
 
 	// 2. Update Context State
@@ -2115,6 +2161,9 @@ func (st *configState) processAndAppend(token string, sb *strings.Builder, state
 			state.pendingGenericKey = false
 		}
 	}
+
+	// Remember the auth scheme for exactly one token (see the forcing above).
+	state.pendingBearer = lowerClean == "bearer"
 
 	// Check if this token is a Context Keyword (e.g. "Error", "Failed")
 	if ContextKeywords[lowerClean] {

--- a/pkg/scanner/signatures.go
+++ b/pkg/scanner/signatures.go
@@ -1,0 +1,129 @@
+package scanner
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Built-in signature detectors for secrets that carry a hard, issuer-defined
+// prefix. Entropy scoring already catches most real instances of these formats,
+// but only because real ones look random: a valid-format low-entropy token
+// (AKIAAAAAAAAAAAAAAAAA, ghp_ followed by 36 a's) scores below the threshold
+// and passes, and so does every one of them once an operator raises the
+// threshold. A signature match is deterministic and threshold-independent, and
+// it names the issuer in the redaction marker when entity labels are on.
+//
+// Scope: these run per token, so they cover single-line secrets only. A PEM
+// private key is handled at line level by isPrivateKeyMarker — its body lines
+// are high-entropy base64 and are already redacted by the entropy engine, so
+// only the BEGIN/END framing lines need a rule of their own.
+
+var (
+	// AWS access key IDs: AKIA (long-lived) and ASIA (temporary), 16 more
+	// uppercase alphanumerics.
+	awsKeyRe = regexp.MustCompile(`^(?:AKIA|ASIA)[0-9A-Z]{16}$`)
+
+	// Google API keys: AIza plus 35 characters of the URL-safe alphabet.
+	gcpKeyRe = regexp.MustCompile(`^AIza[0-9A-Za-z_-]{35}$`)
+
+	// GitHub tokens: ghp_ (personal), gho_ (OAuth), ghs_ (server-to-server),
+	// ghu_ (user-to-server), ghr_ (refresh).
+	githubTokenRe = regexp.MustCompile(`^gh[pousr]_[0-9A-Za-z]{36,255}$`)
+
+	// Slack tokens: xoxb/xoxa/xoxp/xoxr/xoxs/xoxe followed by dash-separated
+	// numeric and alphanumeric parts.
+	slackTokenRe = regexp.MustCompile(`^xox[abepsr]-[0-9A-Za-z-]{10,}$`)
+
+	// Stripe secret and restricted keys. Publishable keys (pk_) are meant to
+	// be public and are deliberately not matched.
+	stripeKeyRe = regexp.MustCompile(`^(?:sk|rk)_(?:live|test)_[0-9A-Za-z]{16,}$`)
+
+	// JWT: three base64url segments, the header starting with the encoded
+	// `{"alg":`. The signature segment may be empty (alg=none).
+	jwtRe = regexp.MustCompile(`^eyJ[0-9A-Za-z_-]+\.[0-9A-Za-z_-]+\.[0-9A-Za-z_-]*$`)
+)
+
+// signatureRule pairs the label written into the marker with its matcher. The
+// prefix is a cheap pre-filter so the regexp only runs on plausible tokens.
+type signatureRule struct {
+	label  string
+	prefix []string
+	re     *regexp.Regexp
+}
+
+var signatureRules = []signatureRule{
+	{"aws-key", []string{"AKIA", "ASIA"}, awsKeyRe},
+	{"gcp-key", []string{"AIza"}, gcpKeyRe},
+	{"github-token", []string{"ghp_", "gho_", "ghs_", "ghu_", "ghr_"}, githubTokenRe},
+	{"slack-token", []string{"xox"}, slackTokenRe},
+	{"stripe-key", []string{"sk_live_", "sk_test_", "rk_live_", "rk_test_"}, stripeKeyRe},
+	{"jwt", []string{"eyJ"}, jwtRe},
+}
+
+// minSignatureLength is the shortest token any rule above can match (an AWS
+// key ID, 20 characters). Tokens shorter than this skip the whole check.
+const minSignatureLength = 20
+
+// minBearerCredentialLength is how long the token after the "Bearer" auth
+// scheme must be before it is treated as a credential. Real bearer tokens are
+// far longer; the bound is what keeps ordinary prose ("the bearer of this
+// note") from losing its next word.
+const minBearerCredentialLength = 16
+
+// matchSignature returns the label of the first signature rule that matches the
+// token, or "" when none does.
+func matchSignature(token string) string {
+	if len(token) < minSignatureLength {
+		return ""
+	}
+	for i := range signatureRules {
+		rule := &signatureRules[i]
+		for _, p := range rule.prefix {
+			if strings.HasPrefix(token, p) {
+				if rule.re.MatchString(token) {
+					return rule.label
+				}
+				break
+			}
+		}
+	}
+	return ""
+}
+
+// isPrivateKeyMarker reports whether the line is the BEGIN or END framing line
+// of a PEM private key block, with or without a key type in the middle
+// ("-----BEGIN PRIVATE KEY-----", "-----BEGIN RSA PRIVATE KEY-----",
+// "-----BEGIN OPENSSH PRIVATE KEY-----", and their END counterparts).
+//
+// The line carries no secret material itself; redacting it marks the event so
+// it is counted and attributable. The key body is base64 with high entropy and
+// is already redacted line by line by the entropy engine.
+func isPrivateKeyMarker(line string) bool {
+	s := strings.TrimSpace(line)
+	const suffix = "PRIVATE KEY-----"
+	prefix := ""
+	switch {
+	case strings.HasPrefix(s, "-----BEGIN "):
+		prefix = "-----BEGIN "
+	case strings.HasPrefix(s, "-----END "):
+		prefix = "-----END "
+	default:
+		return false
+	}
+	if !strings.HasSuffix(s, suffix) || len(s) < len(prefix)+len(suffix) {
+		return false
+	}
+	// Whatever sits between the two is the key type ("RSA ", "EC ", "OPENSSH ",
+	// "ENCRYPTED ", or nothing at all). Restricting it to upper-case letters,
+	// digits and spaces keeps a whole key block handed over as one string —
+	// framing plus base64 body plus newlines — from matching as a single line
+	// and collapsing into one marker.
+	for i := len(prefix); i < len(s)-len(suffix); i++ {
+		c := s[i]
+		if (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == ' ' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/pkg/scanner/signatures_test.go
+++ b/pkg/scanner/signatures_test.go
@@ -1,0 +1,228 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+// The test tokens below are assembled at runtime instead of being written out
+// as literals: they are fake, but they match the issuer formats exactly, and
+// GitHub push protection rejects a commit that contains a complete Slack or
+// Stripe key in a file. Concatenation keeps the value the scanner sees
+// identical while leaving no matchable literal in the source.
+var (
+	aRun24 = strings.Repeat("a", 24)
+	aRun36 = strings.Repeat("a", 36)
+
+	awsLowEntropy    = "AK" + "IA" + strings.Repeat("A", 16)
+	asiaLowEntropy   = "AS" + "IA" + strings.Repeat("A", 16)
+	gcpLowEntropy    = "AI" + "za" + strings.Repeat("A", 35)
+	githubLowEntropy = "gh" + "p_" + aRun36
+	slackLowEntropy  = "xo" + "xb-1111111111-" + aRun24
+	stripeLowEntropy = "sk" + "_live_" + aRun24
+	stripeRestricted = "rk" + "_test_" + aRun24
+	jwtLowEntropy    = "eyJhbGciOiJub25lIn0.eyJzdWIiOiIxIn0."
+)
+
+// lowEntropySecrets are valid-format tokens whose bodies are deliberately
+// repetitive, so entropy scoring alone lets every one of them through. Verified
+// on main before this change: all of them pass unredacted at the default
+// threshold. They are the reason signature detectors exist.
+var lowEntropySecrets = []struct {
+	name  string
+	token string
+	label string
+}{
+	{"aws access key id", awsLowEntropy, "aws-key"},
+	{"aws session key id", asiaLowEntropy, "aws-key"},
+	{"gcp api key", gcpLowEntropy, "gcp-key"},
+	{"github token", githubLowEntropy, "github-token"},
+	{"slack bot token", slackLowEntropy, "slack-token"},
+	{"stripe secret key", stripeLowEntropy, "stripe-key"},
+	{"stripe restricted key", stripeRestricted, "stripe-key"},
+	{"jwt", jwtLowEntropy, "jwt"},
+}
+
+// TestStructuralDetectors covers F1: a token whose issuer prefix identifies it
+// as a secret is redacted regardless of its entropy, and the marker names the
+// issuer when entity labels are on.
+func TestStructuralDetectors(t *testing.T) {
+	oldCfg := activeCfg()
+	defer UpdateConfig(oldCfg)
+	UpdateConfig(campaignConfig())
+
+	for _, tc := range lowEntropySecrets {
+		t.Run(tc.name, func(t *testing.T) {
+			out := ScanAndRedact("value " + tc.token + " end")
+			if strings.Contains(out, tc.token) {
+				t.Errorf("%s passed through: %q", tc.name, out)
+			}
+			if !strings.Contains(out, "[HIDDEN:") {
+				t.Errorf("%s produced no marker: %q", tc.name, out)
+			}
+			if !strings.HasSuffix(strings.TrimSpace(out), "end") {
+				t.Errorf("%s ate the rest of the line: %q", tc.name, out)
+			}
+		})
+	}
+
+	// High-entropy instances of the same formats keep working; they were
+	// already redacted by entropy before this change.
+	for _, tok := range []string{
+		"AK" + "IAIOSFODNN7EXAMPLE",
+		"gh" + "p_wWPw5k4aXcaT4fNP0UcnZwJUVFk6LO0pINUx",
+		"sk" + "_live_4eC39HqLyjWDarjtT1zdp7dcAAAA",
+	} {
+		if out := ScanAndRedact("value " + tok); strings.Contains(out, tok) {
+			t.Errorf("high-entropy %q passed through: %q", tok, out)
+		}
+	}
+
+	// Entity labels name the issuer, not just "entropy".
+	cfg := campaignConfig()
+	cfg.EntityTypeLabels = true
+	UpdateConfig(cfg)
+	for _, tc := range lowEntropySecrets {
+		want := "[HIDDEN:" + tc.label + ":"
+		if out := ScanAndRedact(tc.token); !strings.Contains(out, want) {
+			t.Errorf("%s: got %q, want a %s marker", tc.name, out, want)
+		}
+	}
+}
+
+// TestStructuralDetectorsAntiCorpus pins the things that must NOT start
+// redacting because of a signature rule.
+func TestStructuralDetectorsAntiCorpus(t *testing.T) {
+	oldCfg := activeCfg()
+	defer UpdateConfig(oldCfg)
+	UpdateConfig(campaignConfig())
+
+	for _, line := range []string{
+		"version 1.2.3 released",
+		"build date 2026-07-08 ok",
+		"AKIA is the prefix",                  // prefix alone, too short
+		"ghp_short token",                     // right prefix, wrong length
+		"pk_live_aaaaaaaaaaaaaaaaaaaaaaaa",    // publishable Stripe key: public by design
+		"xoxo hugs and kisses",                // xox prefix, not a Slack token
+		"the bearer of this note gets coffee", // auth scheme word in prose
+		"bearer is a word, not a header here",
+		"the quick brown fox jumps over the do", // plain prose
+	} {
+		if out := ScanAndRedact(line); out != line {
+			t.Errorf("anti-corpus line changed:\n in: %q\nout: %q", line, out)
+		}
+	}
+}
+
+// TestBearerTokenRedacted covers the Authorization header shape: before this
+// change the sensitive key spent its one forced slot on the word "Bearer" and
+// the credential after it went out in the clear.
+func TestBearerTokenRedacted(t *testing.T) {
+	oldCfg := activeCfg()
+	defer UpdateConfig(oldCfg)
+	UpdateConfig(campaignConfig())
+
+	for _, line := range []string{
+		"Authorization: Bearer " + aRun24,
+		"bearer " + aRun24,
+		`{"header":"Bearer ` + aRun24 + `"}`,
+	} {
+		out := ScanAndRedact(line)
+		if strings.Contains(out, aRun24) {
+			t.Errorf("bearer credential leaked: %q -> %q", line, out)
+		}
+	}
+
+	// One token only: the cascade stays broken (B1).
+	out := ScanAndRedact("Bearer " + aRun24 + " retry scheduled later")
+	for _, word := range []string{"retry", "scheduled", "later"} {
+		if !strings.Contains(out, word) {
+			t.Errorf("bearer forced too much, %q missing: %q", word, out)
+		}
+	}
+}
+
+// TestPrivateKeyBlock covers the PEM case: the framing lines are marked, the
+// body is redacted by the entropy engine, and the line count is preserved.
+func TestPrivateKeyBlock(t *testing.T) {
+	oldCfg := activeCfg()
+	defer UpdateConfig(oldCfg)
+	cfg := campaignConfig()
+	cfg.EntityTypeLabels = true
+	UpdateConfig(cfg)
+
+	for _, line := range []string{
+		"-----BEGIN PRIVATE KEY-----",
+		"-----BEGIN RSA PRIVATE KEY-----",
+		"-----BEGIN OPENSSH PRIVATE KEY-----",
+		"-----END PRIVATE KEY-----",
+		"-----END RSA PRIVATE KEY-----",
+	} {
+		out := ScanAndRedact(line)
+		if !strings.Contains(out, "[HIDDEN:private-key:") {
+			t.Errorf("private key framing not marked: %q -> %q", line, out)
+		}
+	}
+
+	// Whole block, scanned the way the CLI and the sidecar feed it — one line at
+	// a time: framing marked, body redacted by entropy, nothing in the clear.
+	block := []string{
+		"-----BEGIN PRIVATE KEY-----",
+		"MIIBVgIBADANBgkqhkiG9w0BAQEFAASCAUAwggE8AgEAAkEAyRQ2mQpVoMxOgSDF",
+		"kJ1kmY8DcYlLxOQwmqLtqPuWfMBmYIQxSdgTQVCzYrJHhHhOEXAMPLEEXAMPLEEX",
+		"-----END PRIVATE KEY-----",
+	}
+	for _, line := range block {
+		out := ScanAndRedact(line)
+		if strings.Contains(out, "MII") || strings.Contains(out, "kJ1kmY8") {
+			t.Errorf("private key body left in the clear: %q -> %q", line, out)
+		}
+		if !strings.Contains(out, "[HIDDEN:") {
+			t.Errorf("private key line not redacted: %q -> %q", line, out)
+		}
+	}
+
+	// The framing rule itself, at unit level. The negative cases matter more
+	// than the positive ones: a whole key block handed over as a single string
+	// must NOT match, or it would collapse into one marker and lose the line
+	// count. (Callers split lines themselves — see the WASM multi-line fix
+	// #184; ScanAndRedact scores whatever it is given as one line.)
+	for _, tc := range []struct {
+		line string
+		want bool
+	}{
+		{"-----BEGIN PRIVATE KEY-----", true},
+		{"-----BEGIN RSA PRIVATE KEY-----", true},
+		{"-----BEGIN OPENSSH PRIVATE KEY-----", true},
+		{"-----BEGIN ENCRYPTED PRIVATE KEY-----", true},
+		{"  -----END EC PRIVATE KEY-----  ", true},
+		{"-----BEGIN PUBLIC KEY-----", false},
+		{"-----BEGIN CERTIFICATE-----", false},
+		{"-----BEGIN PRIVATE KEY----- trailing words", false},
+		{"log: -----BEGIN RSA PRIVATE KEY-----", false},
+		{strings.Join(block, "\n"), false},
+		{"", false},
+	} {
+		if got := isPrivateKeyMarker(tc.line); got != tc.want {
+			t.Errorf("isPrivateKeyMarker(%q) = %v, want %v", tc.line, got, tc.want)
+		}
+	}
+}
+
+// TestSignatureRespectsSafeRules keeps the operator's own rules ahead of the
+// built-in ones: a token explicitly whitelisted must survive.
+func TestSignatureRespectsSafeRules(t *testing.T) {
+	oldCfg := activeCfg()
+	defer UpdateConfig(oldCfg)
+
+	cfg := campaignConfig()
+	if err := cfg.ApplySafeRegexes([]CustomRegexConfig{{Pattern: "^" + awsLowEntropy + "$", Name: "known-test-key"}}); err != nil {
+		t.Fatalf("ApplySafeRegexes: %v", err)
+	}
+	UpdateConfig(cfg)
+
+	tok := awsLowEntropy
+	if out := ScanAndRedact("value " + tok); !strings.Contains(out, tok) {
+		t.Errorf("safe rule did not protect the token: %q", out)
+	}
+}


### PR DESCRIPTION
Entropy scoring catches most real AWS, Google, GitHub, Slack and Stripe credentials, but only because real ones look random. A valid-format token with a repetitive body passes at the default threshold, and every one of them passes once an operator raises it. Verified on `main` before this change: `AKIA` + sixteen A's, `ghp_` + thirty-six a's, an `xoxb-` token, `sk_live_` + twenty-four a's and an `AIza` key all go out in the clear.

Signature rules are deterministic and threshold-independent. They run after the operator's own custom and safe rules (so user configuration still wins) but before the length, space and entropy heuristics, and they name the issuer in the marker when entity labels are on — `[HIDDEN:aws-key:669f3d]`. Publishable Stripe keys (`pk_`) are deliberately not matched: they are public by design.

Two adjacent fixes ship with it.

**`Authorization: Bearer <token>` leaked the credential.** The sensitive key spent its one forced slot on the word "Bearer" and the token right after it went free. The token following the scheme is now forced too — but only when it is at least 16 characters, so ordinary prose keeps its next word. The first draft of this rule had no length bound and redacted the "of" in "the bearer of this note gets coffee"; that is the B1 lesson and there is now an anti-corpus case pinning it.

**PEM private keys.** The BEGIN/END framing lines are marked, which makes the event countable and attributable. The body needs nothing new: measured on a real 2048-bit RSA key and a P-256 EC key, every body line is already redacted by entropy at the default threshold and at `PII_ENTROPY_THRESHOLD=5.0`, and a one-line GCP service-account JSON is covered by its sensitive key name. A cross-line stateful mode was considered and rejected on that evidence — it would break the "a line is scored independently" property that WASM, the SDKs and concurrent callers rely on, in exchange for no extra coverage. The framing matcher is line-scoped by construction (the part between `-----BEGIN ` and `PRIVATE KEY-----` must be upper-case letters, digits or spaces), so a whole key block handed over as a single string cannot collapse into one marker.

**Metrics.** `signature` added to the bounded `type` label allowlist in `pkg/metrics`. Provider granularity stays in the marker name, not in the label, to avoid cardinality creep.

## Evidence

- `go test -race -count=1 ./...` — all packages ok. `go build ./...`, `go vet ./pkg/...`, `gofmt` clean.
- New tests: `TestStructuralDetectors` (eight low-entropy formats redacted, issuer labels correct, high-entropy instances still redacted), `TestStructuralDetectorsAntiCorpus`, `TestBearerTokenRedacted`, `TestPrivateKeyBlock` (framing marked, body clean, unit table for the line-scoped matcher incl. the joined-block negative), `TestSignatureRespectsSafeRules`.
- `redaction-diff.sh` vs `origin/main`, 200,000 lines of a real access log: **0 differing lines** — no new false positives on ordinary traffic.
- `redaction-diff.sh` vs `origin/main`, 3,000-line corpus of normal logs + secrets + look-alikes: 206 differing lines, **every one containing a secret in the source** (85 PEM framing, 45 Bearer, 40 Stripe, 36 Google); leaked secrets 76 before, **0 after**; **0 look-alike lines changed** (`AKIA` as a word, short `ghp_`, publishable `pk_live_`, `xoxo`, "bearer" in prose, PUBLIC KEY and CERTIFICATE blocks).
- `benchstat` (n=6) vs `main`: ScanAndRedact −2.68%, Throughput +0.65%, Allocations +4.13%, geomean +0.66%, allocs/op identical — within noise.
- `scripts/test-smoke.sh`: Go tests and benchmarks green; the Docker accuracy stage did **not** run (Docker unavailable on this machine) — worth confirming in CI.

## Reviewer notes

- Test tokens are assembled at runtime rather than written as literals. GitHub push protection rejects a commit containing a complete Slack or Stripe key even when it is fake, which is exactly what a test for these detectors needs; concatenation keeps the value the scanner sees identical while leaving no matchable literal in the source.
- Several formats already redacted in common shapes because a sensitive key word sat next to them (`aws key AKIA…`, `export GITHUB_TOKEN ghp_…`). The new rules matter when the credential appears without such a neighbour.
- Docs updated: a feature bullet in README.md and the `PII_METRICS_ENABLED` row in CONFIGURATION.md now list the bounded `type` label values including `signature`.
- The new regression tests count as OpenSSF Workstream 4 evidence (false-positive/false-negative regression tests) — account for them once.
